### PR TITLE
[Android] 개인 메시지 화면 레이아웃 구현 #73

### DIFF
--- a/src/android/bbebig-discod-clone/presentation/src/main/java/com/smilegate/bbebig/presentation/component/DiscordEmptyTitleContainer.kt
+++ b/src/android/bbebig-discod-clone/presentation/src/main/java/com/smilegate/bbebig/presentation/component/DiscordEmptyTitleContainer.kt
@@ -1,0 +1,23 @@
+package com.smilegate.bbebig.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DiscordEmptyTitleContainer(modifier: Modifier, firstTitleResId: Int, secondTitleResId: Int) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        Text(stringResource(firstTitleResId), textAlign = TextAlign.Center)
+        Text(stringResource(secondTitleResId), textAlign = TextAlign.Center)
+    }
+}

--- a/src/android/bbebig-discod-clone/presentation/src/main/java/com/smilegate/bbebig/presentation/component/DiscordRoundButton.kt
+++ b/src/android/bbebig-discod-clone/presentation/src/main/java/com/smilegate/bbebig/presentation/component/DiscordRoundButton.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.smilegate.bbebig.presentation.theme.Blue70
 import com.smilegate.bbebig.presentation.theme.White
 import com.smilegate.bbebig.presentation.utils.StableImage
@@ -32,6 +34,7 @@ fun DiscordRoundButton(
     textResId: Int,
     backgroundColor: Color,
     onClick: () -> Unit,
+    textSize: TextUnit = 15.sp,
     iconSize: Dp = 15.dp,
     textColor: Color = Color.Black,
     verticalInnerPadding: Dp = 13.dp,
@@ -63,6 +66,7 @@ fun DiscordRoundButton(
             text = stringResource(id = textResId),
             color = textColor,
             textAlign = TextAlign.Center,
+            fontSize = textSize,
         )
     }
 }

--- a/src/android/bbebig-discod-clone/presentation/src/main/java/com/smilegate/bbebig/presentation/model/ServerType.kt
+++ b/src/android/bbebig-discod-clone/presentation/src/main/java/com/smilegate/bbebig/presentation/model/ServerType.kt
@@ -1,0 +1,6 @@
+package com.smilegate.bbebig.presentation.model
+
+sealed interface ServerType {
+    data object DM : ServerType
+    data object Server : ServerType
+}

--- a/src/android/bbebig-discod-clone/presentation/src/main/java/com/smilegate/bbebig/presentation/ui/login/LoginScreen.kt
+++ b/src/android/bbebig-discod-clone/presentation/src/main/java/com/smilegate/bbebig/presentation/ui/login/LoginScreen.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/src/android/bbebig-discod-clone/presentation/src/main/res/values/strings.xml
+++ b/src/android/bbebig-discod-clone/presentation/src/main/res/values/strings.xml
@@ -29,5 +29,9 @@
     <string name="search_text">검색하기</string>
     <string name="empty_title">한 단계 나아간 그룹 채팅을 이용할\n준비가 되셨나요?</string>
     <string name="empty_sub_title">정리된 대화, 즉흥적 행아웃, 강력한 사용자\n 지정 기능과 함께 커뮤니티를 구축하세요!</string>
+    <string name="add_friend">친구 추가하기</string>
+    <string name="dm_top_title">메시지</string>
+    <string name="dm_sub_title">친구들 초대해 게임도 하고, 노래도\n 듣고, 다양한 활동을 즐기세요.</string>
+    <string name="dm_empty_title">즐거움이 함께하는 DM</string>
 
 </resources>


### PR DESCRIPTION
## 📎 연관 이슈

해결된 이슈: close #73 

## ✏️ 작업 내용
- 개인 메시지 화면 구현 완료했습니다.
- 개인 메시지 화면 빈화면도 구현 완료했슴다.

## 📷 스크린샷 (선택 사항)
<img src = "https://github.com/user-attachments/assets/1b008545-1fb5-4976-bd25-c2c3194285ca" width=300 />