### PR TITLE
[BE] 인증서버 추가 기능 구현 #74

### DIFF
--- a/src/backend/auth-server/src/controllers/auth/index.ts
+++ b/src/backend/auth-server/src/controllers/auth/index.ts
@@ -94,6 +94,8 @@ function authController() {
 
       const result = await authService.refresh(refreshToken, redisRefreshToken);
 
+      app.redis.set(REDIS_KEY.refreshToken(id), result.refreshToken);
+
       return {
         ...SUCCESS_MESSAGE.refreshToken,
         result,
@@ -103,35 +105,11 @@ function authController() {
     }
   };
 
-  const verifyToken = async (req: FastifyRequest, res: FastifyReply) => {
-    const authorization = req.headers.authorization;
-    if (!authorization) {
-      handleError(res, ERROR_MESSAGE.unauthorized);
-      return;
-    }
-
-    const decode = await verifyAccessToken(authorization);
-
-    if (!decode) {
-      handleError(res, ERROR_MESSAGE.unauthorized);
-      return;
-    }
-
-    return {
-      ...SUCCESS_MESSAGE.accessTokenOk,
-      result: {
-        id: decode.id,
-        email: decode.email,
-      },
-    };
-  };
-
   return {
     login,
     register,
     logout,
     refresh,
-    verifyToken,
   };
 }
 

--- a/src/backend/auth-server/src/libs/authHelper.ts
+++ b/src/backend/auth-server/src/libs/authHelper.ts
@@ -49,15 +49,15 @@ const verifyPassword = async (email: string, password: string) => {
   }
 };
 
-const generateAccessToken = (user: { id: number; email: string }) => {
+const generateAccessToken = (user: { id: number }) => {
   const accessToken = jwt.sign({ id: user.id }, SECRET_KEY, {
     expiresIn: ACCESS_TOKEN_EXPIRES,
   });
   return accessToken;
 };
 
-const generateRefreshToken = (user: { id: number; email: string }) => {
-  const refreshToken = jwt.sign({ id: user.id, email: user.email }, SECRET_KEY, {
+const generateRefreshToken = (user: { id: number }) => {
+  const refreshToken = jwt.sign({ id: user.id }, SECRET_KEY, {
     expiresIn: REFRESH_TOKEN_EXPIRES,
   });
   return refreshToken;
@@ -65,9 +65,8 @@ const generateRefreshToken = (user: { id: number; email: string }) => {
 
 const verifySignIn = async (req: FastifyRequest, res: FastifyReply) => {
   const id = req.user?.id;
-  const email = req.user?.email;
 
-  if (id && email) {
+  if (id) {
     return;
   } else {
     handleError(res, ERROR_MESSAGE.unauthorized);

--- a/src/backend/auth-server/src/libs/authHelper.ts
+++ b/src/backend/auth-server/src/libs/authHelper.ts
@@ -50,7 +50,7 @@ const verifyPassword = async (email: string, password: string) => {
 };
 
 const generateAccessToken = (user: { id: number; email: string }) => {
-  const accessToken = jwt.sign({ id: user.id, email: user.email }, SECRET_KEY, {
+  const accessToken = jwt.sign({ id: user.id }, SECRET_KEY, {
     expiresIn: ACCESS_TOKEN_EXPIRES,
   });
   return accessToken;

--- a/src/backend/auth-server/src/libs/responseHelper.ts
+++ b/src/backend/auth-server/src/libs/responseHelper.ts
@@ -1,12 +1,13 @@
 import { FastifyReply } from 'fastify';
 import { CommonResponseType } from 'src/schema/type';
 
-function handleSuccess(res: FastifyReply, data: CommonResponseType, callback?: () => void) {
-  res.log.info(data);
-  res.status(200).send({
-    data,
-  });
-  callback?.();
+function handleSuccess(
+  res: FastifyReply,
+  data: CommonResponseType,
+  callback?: (res: FastifyReply) => void,
+) {
+  res.status(200).send(data);
+  callback?.(res);
 }
 
 export default handleSuccess;

--- a/src/backend/auth-server/src/libs/responseHelper.ts
+++ b/src/backend/auth-server/src/libs/responseHelper.ts
@@ -1,0 +1,12 @@
+import { FastifyReply } from 'fastify';
+import { CommonResponseType } from 'src/schema/type';
+
+function handleSuccess(res: FastifyReply, data: CommonResponseType, callback?: () => void) {
+  res.log.info(data);
+  res.status(200).send({
+    data,
+  });
+  callback?.();
+}
+
+export default handleSuccess;

--- a/src/backend/auth-server/src/routes/auth/index.ts
+++ b/src/backend/auth-server/src/routes/auth/index.ts
@@ -49,13 +49,6 @@ const authRoute = async (app: FastifyInstance) => {
     preHandler: [verifySignIn],
     handler: instanceWrapper(authController.refresh),
   });
-
-  app.withTypeProvider<ZodTypeProvider>().route({
-    method: 'POST',
-    url: '/verify-token',
-    schema: verifyTokenSchema,
-    handler: authController.verifyToken,
-  });
 };
 
 export default authRoute;

--- a/src/backend/auth-server/src/schema/authSchema.ts
+++ b/src/backend/auth-server/src/schema/authSchema.ts
@@ -15,9 +15,7 @@ const signInSchema = {
       code: z.number(),
       message: z.string(),
       result: z.object({
-        email: z.string(),
         accessToken: z.string(),
-        nickname: z.string(),
       }),
     }),
     400: commonResponseSchema,

--- a/src/backend/auth-server/src/schema/authSchema.ts
+++ b/src/backend/auth-server/src/schema/authSchema.ts
@@ -8,7 +8,7 @@ const signInSchema = {
   description: '로그인 합니다.',
   body: z.object({
     email: z.string().email(),
-    password: z.string().min(8),
+    password: z.string(),
   }),
   response: {
     200: z.object({
@@ -26,14 +26,29 @@ const registerSchema = {
   tags: ['auth'],
   description: '회원가입 합니다.',
   body: z.object({
-    email: z.string().email(),
-    password: z.string().min(8),
-    name: z.string().min(2),
-    nickname: z.string().min(2),
+    email: z.string().email('이메일 형식이 올바르지 않습니다.'),
+    password: z
+      .string()
+      .min(8, '비밀번호는 8자 이상이어야 합니다.')
+      .max(20, '비밀번호는 20자 이하여야 합니다.'),
+    name: z
+      .string()
+      .min(2, '이름은 2자 이상이어야 합니다.')
+      .max(20, '이름은 20자 이하여야 합니다.'),
+    nickname: z
+      .string()
+      .min(2, '닉네임은 2자 이상이어야 합니다.')
+      .max(20, '닉네임은 20자 이하여야 합니다.'),
     birthDate: z
       .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/)
-      .transform((str) => new Date(str)),
+      .regex(/^\d{4}-\d{2}-\d{2}$/, '생년월일은 YYYY-MM-DD 형식이어야 합니다.')
+      .transform((str) => new Date(str))
+      .refine((date) => date <= new Date(), {
+        message: '생년월일은 현재 날짜 이전이어야 합니다.',
+      })
+      .refine((date) => date.getFullYear() >= 1900, {
+        message: '생년월일은 1900년 이후여야 합니다.',
+      }),
   }),
   response: {
     201: commonResponseSchema,

--- a/src/backend/auth-server/src/schema/type/index.ts
+++ b/src/backend/auth-server/src/schema/type/index.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod';
+import { commonResponseSchema } from '../commonSchema';
+
+export type CommonResponseType = z.infer<typeof commonResponseSchema>;

--- a/src/backend/auth-server/src/service/authService.ts
+++ b/src/backend/auth-server/src/service/authService.ts
@@ -48,11 +48,9 @@ function authService() {
 
       const accessToken = generateAccessToken({
         id: Number(authenticationUser.id),
-        email: authenticationUser.email,
       });
       const refreshToken = generateRefreshToken({
         id: Number(authenticationUser.id),
-        email: authenticationUser.email,
       });
 
       const returnValue = {
@@ -78,13 +76,14 @@ function authService() {
 
       const userInfo = {
         id: authenticationUser.id,
-        email: authenticationUser.email,
       };
 
-      const accessToken = generateAccessToken(userInfo);
+      const newAccessToken = generateAccessToken(userInfo);
+      const newRefreshToken = generateRefreshToken(userInfo);
 
       return {
-        accessToken,
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
       };
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
## 📎 연관 이슈

해결된 이슈: close #74 

## ✏️ 작업 내용

1. 리프레시 토큰 발급 로직을 변경하였습니다.
토큰을 발급하면 다음 엑세스 토큰, 리프레스 토큰 두 개를 재생성 합니다. 이후 현재 쿠키내에 리프레시 토큰을 변경합니다.

2. zod를 이용한 스키마에서 설정한 에러 메시지가 반환되도록 변경하였습니다.
> 유효성 검사에 맞는 메시지가 반환되도록 쉽게 수정하였습니다.

**회원가입 스키마의 경우**
```ts
const registerSchema = {
  tags: ['auth'],
  description: '회원가입 합니다.',
  body: z.object({
    email: z.string().email('이메일 형식이 올바르지 않습니다.'),
    password: z
      .string()
      .min(8, '비밀번호는 8자 이상이어야 합니다.')
      .max(20, '비밀번호는 20자 이하여야 합니다.'),
    name: z
      .string()
      .min(2, '이름은 2자 이상이어야 합니다.')
      .max(20, '이름은 20자 이하여야 합니다.'),
    nickname: z
      .string()
      .min(2, '닉네임은 2자 이상이어야 합니다.')
      .max(20, '닉네임은 20자 이하여야 합니다.'),
  }),
  response: {
    201: commonResponseSchema,
    400: commonResponseSchema,
  },
};
```

@mnbvcxzyj

zod를 이용한 유효성 검사는 클라이언트 코드에서도 사용할 예정입니다.

**예시 반환**
```json
{
    "code": 400,
    "message": "이름은 20자 이하여야 합니다."
}
```

## 🙏🏻 리뷰 요구 사항

@dh1010a @soeun2537 

코드를 서버 형식에 맞출 것인지, 임의로 설정하는 건지 알려주세요. B1011 이런 식으로 사용한다 하면 문서화 작업 진행하겠습니다. 현재는 아래처럼 400으로 처리 중입니다.



```json
{
    "code": 400,
    "message": "이름은 20자 이하여야 합니다."
}
```
