### PR TITLE
[FE] 공용 커스텀 컴포넌트 구현 및 생성 화면 퍼블리싱 진행 #220

### DIFF
--- a/src/frontend/src/components/custom-modal/custom-modal.stories.tsx
+++ b/src/frontend/src/components/custom-modal/custom-modal.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import { Camera, Plus } from 'lucide-react'
+import { useState } from 'react'
+
+import CustomButton from '../custom-button'
+import CustomModal from '.'
+
+const meta = {
+  title: 'Component/CustomModal',
+  component: CustomModal,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  argTypes: {}
+} satisfies Meta<typeof CustomModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const PrimaryButton: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => fn()
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [isOpen, setIsOpen] = useState(args.isOpen)
+    return (
+      <div className='w-[480px]'>
+        <button onClick={() => setIsOpen(true)}>Open Modal</button>
+        <CustomModal
+          {...args}
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}>
+          <CustomModal.Header onClose={() => setIsOpen(false)}>
+            <h1 className='text-text-normal text-[24px] leading-[30px] text-center font-bold'>
+              서버 커스터마이즈하기
+            </h1>
+            <div className='text-center mt-2 text-gray-10 leading-[20px]'>
+              새로운 서버에 이름과 아이콘을 부여해 개성을 드러내 보세요. 나중에 언제든 바꿀 수
+              있어요.
+            </div>
+          </CustomModal.Header>
+          <CustomModal.Content>
+            <div className='flex flex-col items-center justify-center'>
+              <div className='w-[80px] h-[80px] flex-col rounded-full relative flex items-center justify-center border-2 border-dashed border-gray-10'>
+                <div className='absolute top-0 right-0 w-5 h-5 rounded-full bg-brand flex items-center justify-center'>
+                  <Plus className='w-3 h-3 text-white-100' />
+                </div>
+                <Camera className='w-6 h-6 text-gray-10' />
+                <span className='text-gray-10 text-[12px] leading-[16px] font-medium'>UPLOAD</span>
+              </div>
+            </div>
+            <label className='text-[12px] text-gray-10 mb-2 leading-[24px] font-bold'>
+              서버 이름
+            </label>
+            <input
+              type='text'
+              className='w-full h-[40px] bg-black-80 rounded-[3px] p-[10px] text-text-normal text-[16px] leading-[24px] font-medium'
+            />
+            <div className='text-[12px] mt-2 text-gray-10 leading-[20px]'>
+              서버를 만들면 Discord의{' '}
+              <a
+                href='#'
+                className='text-text-link'>
+                커뮤니티 지침
+              </a>
+              에 동의하게 됩니다.
+            </div>
+          </CustomModal.Content>
+          <CustomModal.Bottom>
+            <div className='flex justify-between'>
+              <button
+                aria-label='뒤로가기'
+                type='button'
+                className='text-white-10 text-[14px] leading-[20px]'>
+                뒤로가기
+              </button>
+              <CustomButton className='py-[2px] px-4 w-[96px] text-[14px] h-[38px]'>
+                만들기
+              </CustomButton>
+            </div>
+          </CustomModal.Bottom>
+        </CustomModal>
+      </div>
+    )
+  }
+}

--- a/src/frontend/src/components/custom-modal/custom-modal.stories.tsx
+++ b/src/frontend/src/components/custom-modal/custom-modal.stories.tsx
@@ -13,15 +13,18 @@ const meta = {
     layout: 'centered'
   },
   tags: ['autodocs'],
-  argTypes: {}
+  argTypes: {
+    isOpen: { control: 'boolean' },
+    onClose: { action: 'close' }
+  }
 } satisfies Meta<typeof CustomModal>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const PrimaryButton: Story = {
+export const Primary: Story = {
   args: {
-    isOpen: true,
+    isOpen: false,
     onClose: () => fn()
   },
   render: (args) => {

--- a/src/frontend/src/components/custom-modal/index.tsx
+++ b/src/frontend/src/components/custom-modal/index.tsx
@@ -1,0 +1,54 @@
+import { X } from 'lucide-react'
+import { ComponentProps, PropsWithChildren } from 'react'
+
+import { cn } from '@/libs/cn'
+
+import Modal from '../modal'
+
+interface HeaderProps {
+  onClose: () => void
+}
+
+const Header = ({ onClose, children }: PropsWithChildren<HeaderProps>) => {
+  return (
+    <div className='w-[440px] pt-6 px-4'>
+      <div className='absolute top-6 right-4'>
+        <button
+          aria-label='닫기'
+          type='button'
+          onClick={onClose}>
+          <X className='w-6 h-6 text-gray-10' />
+        </button>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+const Content = ({ children }: { children: React.ReactNode }) => {
+  return <div className='my-4 px-4 rounded-lg overflow-hidden'>{children}</div>
+}
+
+const Bottom = ({ children }: { children: React.ReactNode }) => {
+  return <div className='p-4 bg-gray-20'>{children}</div>
+}
+
+type CustomModalProps = ComponentProps<typeof Modal>
+
+function Layout({ children, ...props }: CustomModalProps) {
+  return (
+    <Modal
+      {...props}
+      className={cn('bg-black/50', props.className)}>
+      <section className='bg-brand-10 rounded-lg overflow-hidden'>{children}</section>
+    </Modal>
+  )
+}
+
+const CustomModal = Object.assign(Layout, {
+  Header,
+  Content,
+  Bottom
+})
+
+export default CustomModal

--- a/src/frontend/src/components/custom-radio/custom-radio.stories.tsx
+++ b/src/frontend/src/components/custom-radio/custom-radio.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import { useState } from 'react'
+
+import CustomRadio from '.'
+
+const meta = {
+  title: 'Component/CustomRadio',
+  component: CustomRadio,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs']
+} satisfies Meta<typeof CustomRadio>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {
+    label: '채널 유형',
+    items: [
+      {
+        id: '1',
+        label: '텍스트',
+        description: '메시지, 이미지, GIF, 이모지, 의견, 농담을 전송하세요',
+        value: 'TEXT',
+        icon: (
+          <img
+            src='/icon/channel/type-text.svg'
+            alt='텍스트'
+            width={20}
+            height={20}
+          />
+        )
+      },
+      {
+        id: '2',
+        label: '음성',
+        description: '음성, 영상, 화면 공유로 함꼐 어울리세요',
+        value: 'VOICE',
+        icon: (
+          <img
+            src='/icon/channel/type-voice.svg'
+            alt='음성'
+            width={20}
+            height={20}
+          />
+        )
+      }
+    ],
+    selectedItem: { id: '1', label: '텍스트', value: 'TEXT' },
+    onChange: () => fn()
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [selectedItem, setSelectedItem] = useState(args.selectedItem)
+    return (
+      <div className='w-[480px] h-[300px] bg-brand-10 p-4'>
+        <CustomRadio
+          {...args}
+          selectedItem={selectedItem}
+          onChange={setSelectedItem}
+        />
+      </div>
+    )
+  }
+}

--- a/src/frontend/src/components/custom-radio/index.tsx
+++ b/src/frontend/src/components/custom-radio/index.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/libs/cn'
 
-interface RadioItem {
+export interface RadioItem {
   id: string
   label: string
   description?: string

--- a/src/frontend/src/components/custom-radio/index.tsx
+++ b/src/frontend/src/components/custom-radio/index.tsx
@@ -1,0 +1,62 @@
+import { cn } from '@/libs/cn'
+
+interface RadioItem {
+  id: string
+  label: string
+  description?: string
+  value: string
+  icon?: React.ReactNode
+}
+
+interface Props {
+  label: string
+  items: RadioItem[]
+  selectedItem: RadioItem
+  onChange: (item: RadioItem) => void
+}
+
+function CustomRadio({ label, items, selectedItem, onChange }: Props) {
+  return (
+    <div className='flex flex-col gap-2'>
+      <label className='text-gray-10 text-[12px] leading-[20px] font-bold'>{label}</label>
+      <ul className='flex flex-col gap-2'>
+        {items.map((item) => (
+          <li key={item.id}>
+            <button
+              type='button'
+              className={cn(
+                'bg-gray-20 w-full px-[10px] h-full py-[12px] rounded-[3px] flex items-center justify-between',
+                selectedItem.id === item.id && 'bg-gray-80'
+              )}
+              onClick={() => onChange(item)}>
+              <div className='flex items-center'>
+                <div className='text-[#c8d1db]'>{item.icon}</div>
+                <div className='flex flex-col gap-1 ml-3'>
+                  <span className='text-text-normal text-left leading-[20px] font-medium'>
+                    {item.label}
+                  </span>
+                  {item.description && (
+                    <span className='text-[14px] text-white-20 leading-[16px]'>
+                      {item.description}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div
+                className={cn(
+                  'w-5 h-5 border-2 flex items-center justify-center border-white-20 rounded-full',
+                  selectedItem.id === item.id && 'border-white-100'
+                )}>
+                {selectedItem.id === item.id && (
+                  <div className='w-2 h-2 rounded-full bg-white-100' />
+                )}
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default CustomRadio

--- a/src/frontend/src/layouts/main-layout/components/server-create-modal/index.tsx
+++ b/src/frontend/src/layouts/main-layout/components/server-create-modal/index.tsx
@@ -37,7 +37,7 @@ function ServerCreateModal({ isOpen, onClose, ...args }: ServerCreateModalProps)
         <label className='text-[12px] text-gray-10 mb-2 leading-[24px] font-bold'>서버 이름</label>
         <input
           type='text'
-          className='w-full h-[40px] bg-black-80 rounded-[3px] p-[10px] text-text-normal text-[16px] leading-[24px] font-medium'
+          className='outline-none w-full h-[40px] bg-black-80 rounded-[3px] p-[10px] text-text-normal text-[16px] leading-[24px] font-medium'
         />
         <div className='text-[12px] mt-2 text-gray-10 leading-[20px]'>
           서버를 만들면 Discord의{' '}

--- a/src/frontend/src/layouts/main-layout/components/server-create-modal/index.tsx
+++ b/src/frontend/src/layouts/main-layout/components/server-create-modal/index.tsx
@@ -1,0 +1,70 @@
+import { Camera } from 'lucide-react'
+import { Plus } from 'lucide-react'
+import { ComponentProps } from 'react'
+
+import CustomButton from '@/components/custom-button'
+import CustomModal from '@/components/custom-modal'
+
+type ServerCreateModalProps = {
+  isOpen: boolean
+  onClose: () => void
+} & ComponentProps<typeof CustomModal>
+
+function ServerCreateModal({ isOpen, onClose, ...args }: ServerCreateModalProps) {
+  return (
+    <CustomModal
+      {...args}
+      isOpen={isOpen}
+      onClose={onClose}>
+      <CustomModal.Header onClose={onClose}>
+        <h1 className='text-text-normal text-[24px] leading-[30px] text-center font-bold'>
+          서버 커스터마이즈하기
+        </h1>
+        <div className='text-center mt-2 text-gray-10 leading-[20px]'>
+          새로운 서버에 이름과 아이콘을 부여해 개성을 드러내 보세요. 나중에 언제든 바꿀 수 있어요.
+        </div>
+      </CustomModal.Header>
+      <CustomModal.Content>
+        <div className='flex flex-col items-center justify-center'>
+          <div className='w-[80px] h-[80px] flex-col rounded-full relative flex items-center justify-center border-2 border-dashed border-gray-10'>
+            <div className='absolute top-0 right-0 w-5 h-5 rounded-full bg-brand flex items-center justify-center'>
+              <Plus className='w-3 h-3 text-white-100' />
+            </div>
+            <Camera className='w-6 h-6 text-gray-10' />
+            <span className='text-gray-10 text-[12px] leading-[16px] font-medium'>UPLOAD</span>
+          </div>
+        </div>
+        <label className='text-[12px] text-gray-10 mb-2 leading-[24px] font-bold'>서버 이름</label>
+        <input
+          type='text'
+          className='w-full h-[40px] bg-black-80 rounded-[3px] p-[10px] text-text-normal text-[16px] leading-[24px] font-medium'
+        />
+        <div className='text-[12px] mt-2 text-gray-10 leading-[20px]'>
+          서버를 만들면 Discord의{' '}
+          <a
+            href='#'
+            className='text-text-link'>
+            커뮤니티 지침
+          </a>
+          에 동의하게 됩니다.
+        </div>
+      </CustomModal.Content>
+      <CustomModal.Bottom>
+        <div className='flex justify-between'>
+          <button
+            aria-label='뒤로가기'
+            type='button'
+            onClick={onClose}
+            className='text-white-10 text-[14px] leading-[20px]'>
+            뒤로가기
+          </button>
+          <CustomButton className='py-[2px] px-4 w-[96px] text-[14px] h-[38px]'>
+            만들기
+          </CustomButton>
+        </div>
+      </CustomModal.Bottom>
+    </CustomModal>
+  )
+}
+
+export default ServerCreateModal

--- a/src/frontend/src/layouts/main-layout/index.tsx
+++ b/src/frontend/src/layouts/main-layout/index.tsx
@@ -11,6 +11,7 @@ import useMediaSettingsStore from '@/stores/use-media-setting.store'
 
 import ProfileCard from './components/profile-card'
 import ProfileStatusButton from './components/profile-status-button'
+import ServerCreateModal from './components/server-create-modal'
 import SettingModal, { SettingModalTabsID } from './components/setting-modal'
 
 const myServerList = [
@@ -63,7 +64,7 @@ const MainRootLayout = () => {
   })
 
   const [isProfileCardOpen, setIsProfileCardOpen] = useState(false)
-
+  const [isServerCreateModalOpen, setIsServerCreateModalOpen] = useState(false)
   const { muted, toggleAudioInputMute, toggleAudioOutputMute } = useMediaSettingsStore(
     useShallow((state) => ({
       muted: state.muted,
@@ -87,6 +88,10 @@ const MainRootLayout = () => {
     })
   }
 
+  const handleClickServerCreate = () => {
+    setIsServerCreateModalOpen(true)
+  }
+
   const handleClickEditProfileSettingModal = () => {
     setSettingModalState({
       itemId: SettingModalTabsID.myProfile,
@@ -103,6 +108,10 @@ const MainRootLayout = () => {
 
   const handleClickProfile = () => {
     setIsProfileCardOpen((prev) => !prev)
+  }
+
+  const handleClickServerCreateModalClose = () => {
+    setIsServerCreateModalOpen(false)
   }
 
   useEffect(() => {
@@ -164,7 +173,9 @@ const MainRootLayout = () => {
             ))}
             <li>
               <button
+                aria-label='서버 생성'
                 type='button'
+                onClick={handleClickServerCreate}
                 className='flex items-center justify-center w-full'>
                 <div
                   className={cn(
@@ -245,6 +256,10 @@ const MainRootLayout = () => {
         itemId={settingModalState.itemId}
         isOpen={settingModalState.isOpen}
         onClose={handleClickSettingModalClose}
+      />
+      <ServerCreateModal
+        isOpen={isServerCreateModalOpen}
+        onClose={handleClickServerCreateModalClose}
       />
     </>
   )

--- a/src/frontend/src/layouts/main-layout/index.tsx
+++ b/src/frontend/src/layouts/main-layout/index.tsx
@@ -1,3 +1,4 @@
+import { PlusIcon } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router'
 import { useShallow } from 'zustand/shallow'
@@ -161,6 +162,18 @@ const MainRootLayout = () => {
                 />
               </li>
             ))}
+            <li>
+              <button
+                type='button'
+                className='flex items-center justify-center w-full'>
+                <div
+                  className={cn(
+                    'w-[48px] h-[48px] flex items-center justify-center rounded-[48px] bg-brand-10 overflow-hidden transition-all duration-300 hover:rounded-[14px] hover:bg-brand'
+                  )}>
+                  <PlusIcon className='w-5 h-5 text-white' />
+                </div>
+              </button>
+            </li>
           </ul>
         </nav>
         <div className='flex-1 bg-gray-20 relative'>

--- a/src/frontend/src/layouts/server-layout/components/channel-create-modal/channel-create-modal.stories.tsx
+++ b/src/frontend/src/layouts/server-layout/components/channel-create-modal/channel-create-modal.stories.tsx
@@ -23,7 +23,11 @@ type Story = StoryObj<typeof meta>
 export const Primary: Story = {
   args: {
     isOpen: false,
-    onClose: () => fn()
+    onClose: () => fn(),
+    categoryInfo: {
+      id: '1',
+      name: '테스트 카테고리 이름'
+    }
   },
   render: (args) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -32,6 +36,7 @@ export const Primary: Story = {
       <div className='w-[480px]'>
         <button onClick={() => setIsOpen(true)}>Open Modal</button>
         <ChannelCreateModal
+          {...args}
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
         />

--- a/src/frontend/src/layouts/server-layout/components/channel-create-modal/channel-create-modal.stories.tsx
+++ b/src/frontend/src/layouts/server-layout/components/channel-create-modal/channel-create-modal.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import { useState } from 'react'
+
+import ChannelCreateModal from '.'
+
+const meta = {
+  title: 'Layout/ServerLayout/ChannelCreateModal',
+  component: ChannelCreateModal,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    isOpen: { control: 'boolean' },
+    onClose: { action: 'close' }
+  }
+} satisfies Meta<typeof ChannelCreateModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {
+    isOpen: false,
+    onClose: () => fn()
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [isOpen, setIsOpen] = useState(args.isOpen)
+    return (
+      <div className='w-[480px]'>
+        <button onClick={() => setIsOpen(true)}>Open Modal</button>
+        <ChannelCreateModal
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+        />
+      </div>
+    )
+  }
+}

--- a/src/frontend/src/layouts/server-layout/components/channel-create-modal/index.tsx
+++ b/src/frontend/src/layouts/server-layout/components/channel-create-modal/index.tsx
@@ -1,18 +1,115 @@
+import { useState } from 'react'
+
+import CustomButton from '@/components/custom-button'
 import CustomModal from '@/components/custom-modal'
+import CustomRadio, { RadioItem } from '@/components/custom-radio'
+import { cn } from '@/libs/cn'
 
 interface Props {
+  categoryInfo?: {
+    id: string
+    name: string
+  }
   isOpen: boolean
   onClose: () => void
 }
 
-function ChannelCreateModal({ isOpen, onClose }: Props) {
+const CHANNEL_TYPE_ITEMS = [
+  {
+    id: '1',
+    label: '텍스트',
+    description: '메시지, 이미지, GIF, 이모지, 의견, 농담을 전송하세요',
+    value: 'TEXT',
+    icon: (
+      <img
+        src='/icon/channel/type-text.svg'
+        alt='텍스트'
+        width={20}
+        height={20}
+      />
+    )
+  },
+  {
+    id: '2',
+    label: '음성',
+    description: '음성, 영상, 화면 공유로 함꼐 어울리세요',
+    value: 'VOICE',
+    icon: (
+      <img
+        src='/icon/channel/type-voice.svg'
+        alt='음성'
+        width={20}
+        height={20}
+      />
+    )
+  }
+]
+
+function ChannelCreateModal({ isOpen, onClose, categoryInfo }: Props) {
+  const [selectedChannelType, setSelectedChannelType] = useState<RadioItem>(CHANNEL_TYPE_ITEMS[0])
+
+  const handleCreateChannel = () => {
+    console.log('create channel')
+  }
+
   return (
     <CustomModal
       isOpen={isOpen}
       onClose={onClose}>
       <CustomModal.Header onClose={onClose}>
-        <h1>채널 생성</h1>
+        <h1 className='text-text-normal text-[20px] leading-[24px] font-bold'>채널 만들기</h1>
+        {categoryInfo?.name && (
+          <div className='text-gray-10 text-[12px] leading-[16px]'>
+            :{categoryInfo.name}에 속해 있음
+          </div>
+        )}
       </CustomModal.Header>
+      <CustomModal.Content>
+        <CustomRadio
+          label='채널 유형'
+          items={CHANNEL_TYPE_ITEMS}
+          selectedItem={selectedChannelType}
+          onChange={setSelectedChannelType}
+        />
+        <div className='flex flex-col gap-2 mt-6'>
+          <label className='text-white-100 text-[12px] leading-[16px] font-bold'>채널 이름</label>
+          <div className='relative'>
+            <div className='absolute left-[16px] top-1/2 -translate-x-1/2 -translate-y-1/2 w-5 h-5 flex items-center justify-center'>
+              <img
+                src='/icon/channel/type-text.svg'
+                alt='텍스트'
+                width={14}
+                height={14}
+              />
+            </div>
+            <input
+              type='text'
+              placeholder='새로운 채널'
+              className={cn(
+                'w-full outline-none h-[40px] bg-black-80 rounded-[3px] p-[10px] pl-[28px] text-text-normal text-[16px] leading-[24px]'
+              )}
+            />
+          </div>
+        </div>
+      </CustomModal.Content>
+      <CustomModal.Bottom>
+        <div className='flex justify-end gap-2'>
+          <button
+            aria-label='취소'
+            type='button'
+            onClick={onClose}
+            className='text-white-10 leading-[20px] py-[2px] px-4 w-[96px] text-[14px] h-[38px]'>
+            취소
+          </button>
+          <CustomButton
+            aria-label='채널 만들기'
+            type='button'
+            onClick={handleCreateChannel}
+            className='py-[2px] px-4 w-[96px] text-[14px] h-[38px]'>
+            만들기
+          </CustomButton>
+        </div>
+      </CustomModal.Bottom>
     </CustomModal>
   )
 }

--- a/src/frontend/src/layouts/server-layout/components/channel-create-modal/index.tsx
+++ b/src/frontend/src/layouts/server-layout/components/channel-create-modal/index.tsx
@@ -1,0 +1,20 @@
+import CustomModal from '@/components/custom-modal'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+}
+
+function ChannelCreateModal({ isOpen, onClose }: Props) {
+  return (
+    <CustomModal
+      isOpen={isOpen}
+      onClose={onClose}>
+      <CustomModal.Header onClose={onClose}>
+        <h1>채널 생성</h1>
+      </CustomModal.Header>
+    </CustomModal>
+  )
+}
+
+export default ChannelCreateModal

--- a/src/frontend/tailwind.config.ts
+++ b/src/frontend/tailwind.config.ts
@@ -14,7 +14,7 @@ const config: Pick<Config, 'presets' | 'content' | 'theme' | 'plugins'> = {
         'focus-border': '#00b0f4',
         'status-green': '#43b581',
         'text-link': '#00b0f4',
-        'text-normal': '#hsl(210 calc(1 * 9.091%) 87.059% / 1)',
+        'text-normal': 'hsl(210 calc(1 * 9.091%) 87.059% / 1)',
         'off-white': '#f6f6f6',
         'white-10': 'hsl(220 calc(1 * 13.043%) 95.49% / 1)',
         'white-20': 'hsl(215 calc(1 * 8.824%) 73.333% / 1)',


### PR DESCRIPTION
## 📎 연관 이슈

해결된 이슈: close #220

## ✏️ 작업 내용

기능을 연결하기 이전 퍼블리싱을 먼저 진행하여 병합을 진행합니다.

공용 컴포넌트인 `custom-modal`과 `custom-radio`를 구현하였습니다.

svg 이미지가 정상적으로 다운로드 되지 않아, `css`를 이용하여 구현하였습니다.

## 🙏🏻 리뷰 요구 사항

현재 기능을 제외한 모달 두개를 전부 구현해 두었습니다. 해당 부분은 퍼블리싱만 진행한 부분이며, 기능이 들어가야 합니다.

<img src="https://github.com/user-attachments/assets/049d508e-115b-4eac-acda-acf53180a838" width="300" />

<img src="https://github.com/user-attachments/assets/c1f843e8-737f-4205-b778-4e3dd084cf9b" width="300" />

## 📷 스크린샷 (선택 사항)

구현한 `custom-radio`입니다.

![image](https://github.com/user-attachments/assets/eb60eb2a-d820-4557-98ab-aa75277501ef)

