### PR TITLE
[BE] 인증서버 에러코드 반환 수정 #222

### DIFF
--- a/src/backend/auth-server/.env.sample
+++ b/src/backend/auth-server/.env.sample
@@ -20,3 +20,6 @@ REDIS_PORT=6379
 
 # eureka
 SERVER_IP='Eureka 서버 IP'
+
+# eureka
+EUREKA_DISABLED=true # 개발 환경에서는 true로 설정

--- a/src/backend/auth-server/main.ts
+++ b/src/backend/auth-server/main.ts
@@ -12,7 +12,13 @@ import { FastifyCookieOptions } from '@fastify/cookie';
 import routes from './src/routes';
 import cors from '@fastify/cors';
 import fastifyCookie from '@fastify/cookie';
-import { ERROR_MESSAGE, SECRET_KEY, SERVER_IP, SERVER_PORT } from './src/libs/constants';
+import {
+  ERROR_MESSAGE,
+  SECRET_KEY,
+  SERVER_IP,
+  SERVER_PORT,
+  EUREKA_DISABLED,
+} from './src/libs/constants';
 import fastifyRedis from '@fastify/redis';
 import { currentAuthPlugin } from './src/plugin/authPlugin';
 import { fastifySwagger } from '@fastify/swagger';

--- a/src/backend/auth-server/src/controllers/auth/index.ts
+++ b/src/backend/auth-server/src/controllers/auth/index.ts
@@ -83,14 +83,20 @@ function authController() {
   ) => {
     const { email, password, name, nickname, birthdate } = req.body;
 
-    try {
-      const hashedPassword = generateHash(password);
+    const hashedPassword = generateHash(password);
 
+    const isEmailExists = await authService.findUserByEmail(email);
+
+    if (isEmailExists) {
+      handleError(res, ERROR_MESSAGE.duplicateEmail);
+      return;
+    }
+    try {
       await authService.register(email, hashedPassword, name, nickname, birthdate);
 
       handleSuccess(res, SUCCESS_MESSAGE.registerOk, 201);
     } catch (error) {
-      handleError(res, ERROR_MESSAGE.duplicateEmail, error);
+      handleError(res, ERROR_MESSAGE.serverError, error);
     }
   };
 

--- a/src/backend/auth-server/src/libs/constants.ts
+++ b/src/backend/auth-server/src/libs/constants.ts
@@ -3,6 +3,7 @@ import { Secret } from 'jsonwebtoken';
 const isDevelopment = process.env.NODE_ENV === 'development';
 const isProduction = process.env.NODE_ENV === 'production';
 
+const EUREKA_DISABLED = process.env.EUREKA_DISABLED === 'true' || false;
 const SERVER_IP = process.env.SERVER_IP;
 const SERVER_PORT = Number(process.env.SERVER_PORT);
 const SERVER_URL = process.env.SERVER_URL;
@@ -156,4 +157,5 @@ export {
   REDIS_CONTAINER_NAME,
   REDIS_IMAGE,
   REDIS_VOLUME,
+  EUREKA_DISABLED,
 };

--- a/src/backend/auth-server/src/libs/eureka.ts
+++ b/src/backend/auth-server/src/libs/eureka.ts
@@ -1,3 +1,5 @@
+import { EUREKA_DISABLED } from './constants';
+
 interface EurekaConfig {
   instance: {
     app: string;
@@ -9,7 +11,7 @@ interface EurekaConfig {
       '@enabled': string;
     };
     vipAddress: string;
-    statusPageUrl: string,
+    statusPageUrl: string;
     dataCenterInfo: {
       name: string;
       '@class': string;
@@ -35,6 +37,11 @@ class EurekaClient {
 
   async register(): Promise<void> {
     try {
+      if (EUREKA_DISABLED) {
+        console.log('Eureka 등록 비활성화');
+        return;
+      }
+
       const response = await fetch(`${this.baseUrl}/${this.config.instance.app}`, {
         method: 'POST',
         headers: {

--- a/src/backend/auth-server/src/schema/authSchema.ts
+++ b/src/backend/auth-server/src/schema/authSchema.ts
@@ -16,16 +16,7 @@ const signInSchema = {
         accessToken: z.string(),
       }),
     }),
-    400: z.object({
-      code: z.enum(['AUTH001', 'AUTH003', 'AUTH009', 'AUTH012', 'AUTH013']),
-      message: z.enum([
-        'Bad Request',
-        'Password Not Match',
-        'Not Found',
-        'Server Error',
-        'Too Many Requests',
-      ]),
-    }),
+    400: commonResponseSchema,
   },
 };
 
@@ -49,27 +40,22 @@ const registerSchema = {
     birthdate: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/, '생년월일은 YYYY-MM-DD 형식이어야 합니다.')
-      .refine((date) => new Date(date) <= new Date(), {
-        message: '생년월일은 현재 날짜 이전이어야 합니다.',
-      })
-      .refine((date) => new Date(date).getFullYear() >= 1900, {
-        message: '생년월일은 1900년 이후여야 합니다.',
-      }),
+      .refine(
+        (val) => {
+          const date = new Date(val);
+          return !isNaN(date.getTime());
+        },
+        {
+          message: '유효하지 않은 날짜 형식입니다.',
+        },
+      ),
   }),
   response: {
     201: z.object({
       code: z.string().default('AUTH104'),
       message: z.string().default('register success!'),
     }),
-    400: z.object({
-      code: z.enum(['AUTH002', 'AUTH008', 'AUTH010', 'AUTH012']),
-      message: z.enum([
-        'Duplicate Email',
-        'Already Sign Up',
-        'Precondition Failed',
-        'Server Error',
-      ]),
-    }),
+    400: commonResponseSchema,
   },
 };
 
@@ -103,17 +89,7 @@ const logoutSchema = {
       code: z.string().default('AUTH101'),
       message: z.string().default('Logout success!'),
     }),
-    400: z.object({
-      code: z.enum(['AUTH001', 'AUTH004', 'AUTH012', 'AUTH014', 'AUTH015', 'AUTH016']),
-      message: z.enum([
-        'Bad Request',
-        'Unauthorized',
-        'Server Error',
-        'Authorization header is required',
-        'Token expired or invalid',
-        'Token verification failed',
-      ]),
-    }),
+    400: commonResponseSchema,
   },
 };
 
@@ -126,17 +102,7 @@ const verifyTokenSchema = {
       code: z.string().default('AUTH105'),
       message: z.string().default('token verify success!'),
     }),
-    401: z.object({
-      code: z.enum(['AUTH004', 'AUTH011', 'AUTH014', 'AUTH015', 'AUTH016', 'AUTH017']),
-      message: z.enum([
-        'Unauthorized',
-        'Verify Token Failed',
-        'Authorization header is required',
-        'Token expired or invalid',
-        'Token verification failed',
-        'Access Token Decode Failed',
-      ]),
-    }),
+    401: commonResponseSchema,
   },
 };
 
@@ -152,18 +118,7 @@ const verifyEmailSchema = {
       code: z.enum(['AUTH106']),
       message: z.enum(['email verify success!']),
     }),
-    400: z.object({
-      code: z.enum(['AUTH001', 'AUTH002', 'AUTH012', 'AUTH014', 'AUTH015', 'AUTH016', 'AUTH017']),
-      message: z.enum([
-        'Bad Request',
-        'Duplicate Email',
-        'Server Error',
-        'Authorization header is required',
-        'Token expired or invalid',
-        'Token verification failed',
-        'Access Token Decode Failed',
-      ]),
-    }),
+    400: commonResponseSchema,
   },
 };
 
@@ -180,22 +135,7 @@ const tokenDecodeSchema = {
         valid: z.boolean(),
       }),
     }),
-    400: z.object({
-      code: z.enum(['AUTH001', 'AUTH004', 'AUTH012', 'AUTH014', 'AUTH015', 'AUTH016', 'AUTH017']),
-      message: z.enum([
-        'Bad Request',
-        'Unauthorized',
-        'Server Error',
-        'Authorization header is required',
-        'Token expired or invalid',
-        'Token verification failed',
-        'Access Token Decode Failed',
-      ]),
-      result: z.object({
-        memberId: z.number().default(-1),
-        valid: z.boolean().default(false),
-      }),
-    }),
+    400: commonResponseSchema,
   },
 };
 

--- a/src/backend/auth-server/src/service/authService.ts
+++ b/src/backend/auth-server/src/service/authService.ts
@@ -10,6 +10,15 @@ import { ERROR_MESSAGE } from '../libs/constants';
 import db from '../libs/db';
 
 function authService() {
+  const findUserByEmail = async (email: string) => {
+    const user = await db.member.findFirst({
+      where: {
+        email,
+      },
+    });
+    return user;
+  };
+
   const register = async (
     email: string,
     password: string,
@@ -23,7 +32,7 @@ function authService() {
         password,
         name,
         nickname,
-        birthdate,
+        birthdate: new Date(birthdate),
       },
     });
 
@@ -114,6 +123,7 @@ function authService() {
   };
 
   return {
+    findUserByEmail,
     register,
     loginWithPassword,
     refresh,


### PR DESCRIPTION
## 📎 연관 이슈

해결된 이슈: close #222

## ✏️ 작업 내용

환경변수로 유레카를 비활성화하는 로직을 추가하였습니다.

아래 환경변수를 추가할경우 유레카 로직을 활성화하지 않기 때문에 로컬에서도 정상적으로 실행이 가능합니다.
```text
EUREKA_DISABLED=true
```

현재 에러코드가 정상적으로 반환이 되지 않은 경우는 다음과 같은 상황에서 일어났습니다.

`zod`라는 유효성 검사 라이브러리를 통해 request, response 값을 엄격하게 검사하고있었습니다. 

```ts
400: z.object({
  code: z.enum(['AUTH001', 'AUTH003', 'AUTH009', 'AUTH012', 'AUTH013']),
  message: z.enum([
    'Bad Request',
    'Password Not Match',
    'Not Found',
    'Server Error',
    'Too Many Requests',
  ]),
}),
```

하지만 중간에 세부 검사 로직이 추가하거나, 개발자가 의도하지 않은 에러가 발생했을때는, 500번대 에러를 반환하는 것이였습니다.

때문에 공용 `commonResponse` 값으로 변경하여 반환을 하도록 변경하였습니다.

> Java로 한다면 저희 규격 타입으로 명시하여 어떻게 반환이 되던지 상관없도록 변경하였습니다.

## 📷 스크린샷 (선택 사항)

<img width="577" alt="image" src="https://github.com/user-attachments/assets/e893c068-8614-4398-acaa-1dee83a2aa72" />

