### PR TITLE
[FE] 전체 친구 목록 API 연동 및 DM창 이동 #298

### DIFF
--- a/src/frontend/src/apis/schema/types/user.ts
+++ b/src/frontend/src/apis/schema/types/user.ts
@@ -73,6 +73,24 @@ export interface GetFriendAcceptedListResponseSchema {
   friendEmail: string
 }
 
+export interface GetFriendListResponseSchema {
+  memberId: number
+  friendsCount: number
+  friends: {
+    friendId: number
+    memberId: number
+    memberName: string
+    memberNickname: string
+    memberAvatarUrl: string | null
+    memberBannerUrl: string | null
+    memberIntroduce: string | null
+    memberEmail: string
+    actualStatus: string
+    globalStatus: string
+    createdAt: string | null
+  }[]
+}
+
 export interface DeclineFriendRequestSchema {
   friendId: number
 }

--- a/src/frontend/src/apis/service/user.ts
+++ b/src/frontend/src/apis/service/user.ts
@@ -13,6 +13,7 @@ import {
   DeleteFriendResponseSchema,
   DeleteMemberResponseSchema,
   GetFriendAcceptedListResponseSchema,
+  GetFriendListResponseSchema,
   GetFriendPendingListResponseSchema,
   GetUserRequestSchema,
   GetUserResponseSchema,
@@ -91,6 +92,13 @@ const userService = () => {
     return response.data
   }
 
+  const getFriendList = async () => {
+    const response = await axiosInstance.get<CommonResponseType<GetFriendListResponseSchema>>(
+      `${FRIEND_PATH}`
+    )
+    return response.data
+  }
+
   const declineFriend = async (data: DeclineFriendRequestSchema) => {
     const response = await axiosInstance.delete<CommonResponseType<DeclineFriendResponseSchema>>(
       `${FRIEND_PATH}/${data.friendId}/decline`
@@ -121,6 +129,7 @@ const userService = () => {
     deleteFriend,
     getFriendPendingList,
     getFriendAcceptedList,
+    getFriendList,
     declineFriend,
     acceptFriend,
     deleteFriendInRequestList,

--- a/src/frontend/src/components/user-list-item/index.tsx
+++ b/src/frontend/src/components/user-list-item/index.tsx
@@ -12,8 +12,8 @@ interface UserListItemProps {
   status: CustomPresenceStatus
   statusColor?: string
   iconType: 'default' | 'request' | 'response'
-  handleNavigateToDM: (id: number) => void
-  handleDMIconClick: (e: React.MouseEvent<HTMLButtonElement>, id: number) => void
+  handleNavigateToDM?: (id: number) => void
+  handleDMIconClick?: (e: React.MouseEvent<HTMLButtonElement>, id: number) => void
 }
 
 const ICON_PATH = {
@@ -36,7 +36,7 @@ export function Inner({
   return (
     <div
       className='group flex items-center justify-between p-2 hover:bg-discord-gray-500 rounded cursor-pointer'
-      onClick={() => handleNavigateToDM(id)}>
+      onClick={() => handleNavigateToDM?.(id)}>
       <div className='flex items-center gap-3'>
         <Avatar
           name={name}

--- a/src/frontend/src/hooks/queries/user/useGetFriendList.ts
+++ b/src/frontend/src/hooks/queries/user/useGetFriendList.ts
@@ -1,0 +1,20 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+import { CommonResponseType } from '@/apis/schema/types/common'
+import { GetFriendListResponseSchema } from '@/apis/schema/types/user'
+import userService from '@/apis/service/user'
+import { UseQueryCustomOptions } from '@/types/common'
+
+function useGetFriendList(
+  config?: UseQueryCustomOptions<CommonResponseType<GetFriendListResponseSchema>>
+) {
+  const { data } = useSuspenseQuery({
+    ...config,
+    queryKey: ['friend', 'list'],
+    queryFn: userService.getFriendList
+  })
+
+  return data.result
+}
+
+export default useGetFriendList

--- a/src/frontend/src/pages/dm/components/dm-area-header.tsx
+++ b/src/frontend/src/pages/dm/components/dm-area-header.tsx
@@ -11,17 +11,17 @@ function DmAreaHeader({ friend }: DmAreaHeaderProps) {
         className='relative group'
         role='button'
         tabIndex={0}
-        aria-label={`${friend.name}의 프로필 사진`}>
+        aria-label={`${friend.memberName}의 프로필 사진`}>
         <img
-          src={friend.avatarUrl}
-          alt={`${friend.name}의 프로필`}
+          src={friend.memberAvatarUrl ?? '/image/common/default-avatar.png'}
+          alt={`${friend.memberName}의 프로필`}
           className='w-20 h-20 rounded-full'
         />
       </div>
       <div className='flex flex-col gap-1'>
-        <h2 className='text-2xl font-bold text-discord-font-color-normal'>{friend.name}</h2>
+        <h2 className='text-2xl font-bold text-discord-font-color-normal'>{friend.memberName}</h2>
         <p className='text-discord-gray-200 text-sm'>
-          <span className='text-discord-gray-100 font-medium'>{friend.name}</span>
+          <span className='text-discord-gray-100 font-medium'>{friend.memberNickname}</span>
           님과 나눈 다이렉트 메시지의 첫 부분이에요
         </p>
       </div>

--- a/src/frontend/src/pages/dm/components/dm-area.tsx
+++ b/src/frontend/src/pages/dm/components/dm-area.tsx
@@ -3,24 +3,13 @@ import { useEffect, useRef, useState } from 'react'
 import Avatar from '@/components/avatar'
 import { Friend } from '@/types/friend'
 import { Message } from '@/types/message'
-import { User } from '@/types/user'
+import { CustomPresenceStatus } from '@/types/user'
 import timeHelper from '@/utils/format-time'
 
 import DmAreaHeader from './dm-area-header'
 
 interface DmPageProps {
   friend: Friend
-}
-
-const DUMMY_USER: User = {
-  id: '1',
-  avatarUrl: '/image/homepage/background-art.png',
-  name: '이소은',
-  email: 'soeun@gmail.com',
-  bannerUrl: '/image/common/default-background.png',
-  customPresenceStatus: 'ONLINE',
-  introduction: '안녕하세요',
-  introductionEmoji: '👋'
 }
 
 function DmArea({ friend }: DmPageProps) {
@@ -33,7 +22,7 @@ function DmArea({ friend }: DmPageProps) {
   const handleScroll = () => {
     if (!containerRef.current) return
 
-    if (!messages[friend.id]?.length) {
+    if (!messages[friend.memberId]?.length) {
       setShowTopHeader(true)
       return
     }
@@ -43,7 +32,7 @@ function DmArea({ friend }: DmPageProps) {
   }
 
   const sendMessage = () => {
-    if (!inputRef.current || !friend.id) return
+    if (!inputRef.current || !friend.memberId) return
     const text = inputRef.current.value.trim()
     if (!text) return
 
@@ -58,7 +47,7 @@ function DmArea({ friend }: DmPageProps) {
 
     setMessages((prev) => ({
       ...prev,
-      [friend.id]: [...(prev[friend.id] || []), newMessage]
+      [friend.memberId]: [...(prev[friend.memberId] || []), newMessage]
     }))
 
     inputRef.current.value = ''
@@ -89,7 +78,7 @@ function DmArea({ friend }: DmPageProps) {
           className='flex-1 overflow-y-auto'>
           <div
             className={`transition-opacity duration-200 ${
-              showTopHeader || !messages[friend.id]?.length
+              showTopHeader || !messages[friend.memberId]?.length
                 ? 'opacity-100'
                 : 'opacity-0 h-0 overflow-hidden'
             }`}>
@@ -97,13 +86,13 @@ function DmArea({ friend }: DmPageProps) {
           </div>
 
           <div className='flex flex-col justify-end min-h-full p-4'>
-            {friend.id &&
-              messages[friend.id]?.map((msg) => {
+            {friend.memberId &&
+              messages[friend.memberId]?.map((msg) => {
                 const { isToday, ampm, hour12, minutes, year, month, day } = timeHelper(
                   msg.createdAt.toISOString()
                 )
 
-                const isMyMessage = msg.memberId === DUMMY_USER.id
+                const isMyMessage = msg.memberId === friend.memberId.toString()
 
                 return (
                   <div
@@ -111,14 +100,15 @@ function DmArea({ friend }: DmPageProps) {
                     className='flex items-start gap-3 mb-4'>
                     <Avatar
                       size='sm'
-                      avatarUrl={isMyMessage ? DUMMY_USER.avatarUrl : friend.avatarUrl}
+                      avatarUrl={isMyMessage ? friend.memberAvatarUrl : friend.memberAvatarUrl}
                       statusColor='black'
-                      status={isMyMessage ? DUMMY_USER.customPresenceStatus : friend.status}
+                      status={friend.actualStatus as CustomPresenceStatus}
+                      name={isMyMessage ? friend.memberName : friend.memberName}
                     />
 
                     <div className='flex-1'>
                       <div className='text-sm font-bold text-discord-font-color-normal'>
-                        {isMyMessage ? DUMMY_USER.name : friend.name}
+                        {isMyMessage ? friend.memberName : friend.memberName}
                         <span className='ml-2 text-xs text-gray-400'>
                           {isToday
                             ? `오늘 ${ampm} ${hour12}:${minutes}`

--- a/src/frontend/src/pages/dm/components/dm-header.tsx
+++ b/src/frontend/src/pages/dm/components/dm-header.tsx
@@ -10,11 +10,13 @@ function DmHeader({ friend }: DmHeaderProps) {
     <div className='flex h-12 items-center gap-2 '>
       <Avatar
         statusColor='black'
-        avatarUrl={friend.avatarUrl}
-        status={friend.status}
+        avatarUrl={friend.memberAvatarUrl}
         size='sm'
+        name={friend.memberNickname}
       />
-      <span className='text-discord-font-color-normal text-base font-semibold'>{friend.name}</span>
+      <span className='text-discord-font-color-normal text-base font-semibold'>
+        {friend.memberName}
+      </span>
     </div>
   )
 }

--- a/src/frontend/src/pages/dm/index.tsx
+++ b/src/frontend/src/pages/dm/index.tsx
@@ -1,36 +1,23 @@
-import { ChangeEvent, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { ChangeEvent, Suspense, useState } from 'react'
 import { useParams } from 'react-router'
 
 import CommonHeader from '@/components/common-header'
+import LoadingIcon from '@/components/loading-icon'
 import { Friend } from '@/types/friend'
 
 import DmArea from './components/dm-area'
 import DmHeader from './components/dm-header'
-const DUMMY_FRIENDS: Friend[] = [
-  {
-    id: 1,
-    avatarUrl: '/image/common/default-avatar.png',
-    name: '이지형',
-    status: 'ONLINE'
-  },
-  {
-    id: 2,
-    avatarUrl: '/image/common/default-avatar.png',
-    name: '김예지',
-    status: 'OFFLINE'
-  },
-  {
-    id: 3,
-    avatarUrl: '/image/common/default-avatar.png',
-    name: '서정우',
-    status: 'OFFLINE'
-  }
-]
 
 function DmPage() {
-  const { friendId } = useParams()
+  const { friendId } = useParams<{ friendId: string }>()
   const [searchValue, setSearchValue] = useState('')
-  const selectedFriend = DUMMY_FRIENDS.find((friend) => friend.id === Number(friendId))
+  const queryClient = useQueryClient()
+
+  const friendData = queryClient.getQueryData<{ result: { friends: Friend[] } }>(['friend', 'list'])
+
+  const selectedFriend = friendData?.result.friends.find((f) => f.memberId === Number(friendId))
+
   const handleSearch = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(e.target.value)
   }
@@ -54,7 +41,9 @@ function DmPage() {
         }}>
         <DmHeader friend={selectedFriend} />
       </CommonHeader>
-      <DmArea friend={selectedFriend} />
+      <Suspense fallback={<LoadingIcon />}>
+        <DmArea friend={selectedFriend} />
+      </Suspense>
     </div>
   )
 }

--- a/src/frontend/src/pages/friend/components/all-friends.tsx
+++ b/src/frontend/src/pages/friend/components/all-friends.tsx
@@ -1,35 +1,17 @@
 import { ChangeEvent, useState } from 'react'
 
 import SearchInput from '@/components/search-input'
-import UserListItem from '@/components/user-list-item'
+import UserListItemLink from '@/components/user-list-item'
 import { statusKo } from '@/constants/status'
-import { Friend } from '@/types/friend'
-
-const DUMMY_FRIENDS: Friend[] = [
-  {
-    id: 1,
-    avatarUrl: '/image/common/default-avatar.png',
-    name: '이지형',
-    status: 'ONLINE'
-  },
-  {
-    id: 2,
-    avatarUrl: '/image/common/default-avatar.png',
-    name: '김예지',
-    status: 'OFFLINE'
-  },
-  {
-    id: 3,
-    avatarUrl: '/image/common/default-avatar.png',
-    name: '서정우',
-    status: 'OFFLINE'
-  }
-]
+import useGetFriendList from '@/hooks/queries/user/useGetFriendList'
+import { CustomPresenceStatus } from '@/types/user'
 
 function AllFriends() {
+  const { friends = [] } = useGetFriendList()
   const [searchValue, setSearchValue] = useState('')
-  const filteredFriends = DUMMY_FRIENDS.filter((friend) =>
-    friend.name.toLowerCase().includes(searchValue.toLowerCase())
+
+  const filteredFriends = friends.filter((friend) =>
+    friend.memberName.toLowerCase().includes(searchValue.toLowerCase())
   )
 
   const handleSearch = (e: ChangeEvent<HTMLInputElement>) => {
@@ -58,13 +40,13 @@ function AllFriends() {
           </div>
         )}
         {filteredFriends.map((friend) => (
-          <UserListItem
-            key={friend.id}
-            id={friend.id}
-            avatarUrl={friend.avatarUrl}
-            name={friend.name}
-            status={friend.status}
-            description={statusKo[friend.status]}
+          <UserListItemLink
+            key={friend.friendId}
+            id={friend.memberId}
+            avatarUrl={friend.memberAvatarUrl ?? '/image/common/default-avatar.png'}
+            name={friend.memberName}
+            status={friend.actualStatus as CustomPresenceStatus}
+            description={statusKo[friend.actualStatus as CustomPresenceStatus]}
             statusColor='black'
             iconType='default'
           />

--- a/src/frontend/src/types/friend.ts
+++ b/src/frontend/src/types/friend.ts
@@ -1,12 +1,14 @@
 export interface Friend {
   friendId: number
-  friendMemberId: number
-  friendName: string
-  friendNickname: string
-  friendAvatarUrl: string
-  friendBannerUrl: string
-  friendIntroduce: string
-  friendEmail: string
+  memberId: number
+  memberName: string
+  memberNickname: string
+  memberAvatarUrl: string | null
+  memberBannerUrl: string | null
+  memberIntroduce: string | null
+  memberEmail: string
+  actualStatus: string
+  globalStatus: string
 }
 
 export type FriendStatus = 'PENDING' | 'DECLINED' | 'ACCEPTED'


### PR DESCRIPTION
## 📎 연관 이슈

해결된 이슈: close #298 

## ✏️ 작업 내용
전체 친구 목록 API를 연동하였습니다. 임시 계정 2개 생성하여 친구 연결해두고 테스트 했습니다! 
API 명세에 필드 이름이 바뀌어서 Friend 파일이 수정되었습니다! 사용하시는 부분 있다면 확인 부탁드립니다 
전체 친구목록에서 -> 해당 사용자 누르면 DM창 으로 이동하게끔 해두었습니다. 
현재 소켓 연결 전이라서 정보 수정(사용자 상태 변경, 이름 변경 등) 아직 반영이 되지 않는데 추후 반영되게 해두겠습니다

## 🙏🏻 리뷰 요구 사항

## 📷 스크린샷 (선택 사항)
<img width="778" alt="image" src="https://github.com/user-attachments/assets/c8e2bdf6-7fea-4753-a1f0-e4c41148a2b4" />
