### PR TITLE
[FE] 서버 구독 이벤트 타입 처리 #304

### DIFF
--- a/src/frontend/src/hooks/store/use-chatting-stomp.ts
+++ b/src/frontend/src/hooks/store/use-chatting-stomp.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { chattingStompInstance } from '@/apis/config/stomp-instance'
 import { COOKIE_KEYS } from '@/constants/keys'
-import { ChatMessageRequest } from '@/types/stomp'
+import { ChatMessageRequest } from '@/types/ChatStompEvent'
 import cookie from '@/utils/cookie'
 
 export const useChattingStomp = () => {

--- a/src/frontend/src/types/ChatStompEvent.ts
+++ b/src/frontend/src/types/ChatStompEvent.ts
@@ -1,0 +1,64 @@
+// 🛜 SUBSCRIBE
+// 서버 채널 생성/수정/삭제 이벤트
+export interface ServerChannelEvent {
+  serverId: number
+  type: 'SEVER_CHANNEL'
+  categoryId: number
+  channeId: number
+  channelType: 'CHAT' | 'VOICE'
+  order: number | null
+  status: 'CREATE' | 'UPDATE' | 'DELETE'
+}
+
+// 서버 카테고리 생성/수정/삭제 이벤트
+export interface ServerCategoryEvent {
+  serverId: number
+  type: 'SEVER_CATEGORY'
+  categoryId: number
+  categoryName: string | null
+  order: number | null
+  status: 'CREATE' | 'UPDATE' | 'DELETE'
+}
+
+// 서버 수정/삭제 이벤트
+export interface ServerActionEvent {
+  serverId: number
+  type: 'SEVER_ACTION'
+  serverName: string | null
+  profileImageUrl: string | null
+  status: 'UPDATE' | 'DELETE'
+}
+
+// 서버 멤버 참여/탈퇴/수정 이벤트
+export interface ServerMemberActionEvent {
+  serverId: number
+  type: 'SERVER_MEMBER_ACTION'
+  memberId: number
+  nickName: string | null
+  avatarUrl: string | null
+  bannerUrl: string | null
+  status: 'JOIN' | 'LEAVE' | 'UPDATE'
+}
+
+// 서버 멤버 온/오프라인 상태 업데이트 이벤트
+export interface ServerMemberPresenceEvent {
+  serverId: number
+  type: 'SERVER_MEMBER_PRESENCE'
+  memberId: number
+  actualStatus: 'ONLINE' | 'OFFLINE'
+  globalStatus: 'ONLINE' | 'OFFLINE' | 'AWAY' | 'BUSY' | 'DND'
+}
+
+// 서버 채팅 메시지 이벤트
+export interface ChatMessageRequest {
+  id: number
+  channelType: 'CHANNEL' | 'DM'
+  messageType: 'TEXT'
+  type: 'MESSAGE_CREATE' | 'MESSAGE_UPDATE' | 'MESSAGE_DELETE'
+  serverId: number
+  channelId: number
+  sendMemberId: number
+  content: string
+  createdAt?: string
+  updatedAt?: string
+}

--- a/src/frontend/src/types/stomp.ts
+++ b/src/frontend/src/types/stomp.ts
@@ -12,37 +12,3 @@ export interface StompState {
   send: (destination: string, body: any) => void
   message: (destination: string, body: any) => void
 }
-
-// 서버 채널 메시지 타입
-export interface ChatMessageRequest {
-  id: number
-  channelType: 'CHANNEL' | 'DM'
-  messageType: 'TEXT' | 'IMAGE' | 'VIDEO' | 'FILE' | 'SYSTEM'
-  type: 'MESSAGE_CREATE' | 'MESSAGE_UPDATE' | 'MESSAGE_DELETE'
-  serverId: number
-  channelId: number
-  sendMemberId: number
-  content: string
-  createdAt?: string
-  updatedAt?: string
-}
-
-// 채널 입/퇴장
-export interface ChannelPresenceRequest {
-  memberId: number
-  type: 'ENTER' | 'LEAVE'
-  channelType: 'CHANNEL' | 'DM'
-  serverId: number
-  channelId: number
-  lastReadMessageId?: string
-  eventTime: string
-}
-
-// 타이핑 상태 요청
-export interface TypingRequest {
-  memberId: number
-  type: 'TYPING_START'
-  memberNickname: string
-  serverId: number
-  channelId: number
-}


### PR DESCRIPTION
## 📎 연관 이슈

해결된 이슈: close #304 

## ✏️ 작업 내용
서버 구독에서 발생할 수 있는 이벤트들을 따로 타입 정의해두었습니다. 
추후 message 받을 때, 해당 타입 사용해서 다음 액션 처리 하시면 될 거 같습니다 

