### PR TITLE
[BE] 메시지에 채널별 시퀀스 추가

### DIFF
--- a/src/backend/common-module/src/main/java/com/bbebig/commonmodule/clientDto/SearchFeignResponseDto.java
+++ b/src/backend/common-module/src/main/java/com/bbebig/commonmodule/clientDto/SearchFeignResponseDto.java
@@ -1,0 +1,18 @@
+package com.bbebig.commonmodule.clientDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class SearchFeignResponseDto {
+
+	@Data
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class ServerChannelSequenceResponseDto {
+		private Long channelId;
+		private Long lastSequence;
+	}
+}

--- a/src/backend/search-server/src/main/java/com/bbebig/searchserver/domain/history/repository/ChannelChatMessageRepository.java
+++ b/src/backend/search-server/src/main/java/com/bbebig/searchserver/domain/history/repository/ChannelChatMessageRepository.java
@@ -24,4 +24,7 @@ public interface ChannelChatMessageRepository extends MongoRepository<ChannelCha
 	);
 
 	List<ChannelChatMessage> findByChannelId(Long channelId, Pageable pageable);
+
+	@Query(value = "{ 'channelId': ?0, 'deleted': false }", sort = "{ 'id': -1 }")
+	Optional<ChannelChatMessage> findTopByChannelIdOrderByIdDesc(Long channelId);
 }

--- a/src/backend/search-server/src/main/java/com/bbebig/searchserver/global/feign/FeignController.java
+++ b/src/backend/search-server/src/main/java/com/bbebig/searchserver/global/feign/FeignController.java
@@ -1,0 +1,29 @@
+package com.bbebig.searchserver.global.feign;
+
+
+import com.bbebig.commonmodule.clientDto.SearchFeignResponseDto;
+import com.bbebig.commonmodule.clientDto.SearchFeignResponseDto.ServerChannelSequenceResponseDto;
+import com.bbebig.searchserver.domain.history.service.HistoryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/feign")
+@RequiredArgsConstructor
+@Tag(name = "Feign", description = "서버 내부 호출에서 사용되는 관련 API")
+public class FeignController {
+
+	private final HistoryService historyService;
+
+	@GetMapping("/channels/{channelId}/sequence")
+	public ServerChannelSequenceResponseDto getChannelLastSequence(@PathVariable(value = "channelId") Long channelId) {
+		log.info("[Feign] 채널 마지막 시퀀스 조회 요청: channelId = {}", channelId);
+		return historyService.getChannelLastSequence(channelId);
+	}
+}

--- a/src/backend/search-server/src/main/java/com/bbebig/searchserver/global/repository/ServerRedisRepositoryImpl.java
+++ b/src/backend/search-server/src/main/java/com/bbebig/searchserver/global/repository/ServerRedisRepositoryImpl.java
@@ -206,4 +206,19 @@ public class ServerRedisRepositoryImpl implements ServerRedisRepository {
 				.count();
 	}
 
+	/**
+	 * 서버별 채널 시퀀스 정보를 저장
+	 * (serverChannel:{serverId}:channelSequence) => ChannelId, Sequence
+	 */
+	public void saveServerChannelSequence(Long channelId, Long sequence) {
+		String redisKey = ServerRedisKeys.getServerChannelSequenceKey(channelId);
+		redisSetTemplate.opsForValue().set(redisKey, sequence);
+	}
+
+	// 서버별 채널 시퀀스 정보 조회
+	public Long getServerChannelSequence(Long channelId) {
+		String redisKey = ServerRedisKeys.getServerChannelSequenceKey(channelId);
+		return redisSetTemplate.opsForValue().get(redisKey);
+	}
+
 }

--- a/src/backend/service-server/src/main/java/com/bbebig/serviceserver/channel/entity/Channel.java
+++ b/src/backend/service-server/src/main/java/com/bbebig/serviceserver/channel/entity/Channel.java
@@ -46,6 +46,9 @@ public class Channel extends BaseTimeEntity {
     @Column(name = "private_status")
     private boolean privateStatus;
 
+    @Column(name = "last_sequence")
+    private Long lastSequence;
+
     public void update(ChannelUpdateRequestDto channelUpdateRequestDto) {
         this.name = channelUpdateRequestDto.getChannelName();
         this.privateStatus = channelUpdateRequestDto.isPrivateStatus();
@@ -57,5 +60,9 @@ public class Channel extends BaseTimeEntity {
 
     public void updatePosition(int position) {
         this.position = position;
+    }
+
+    public void updateLastSequence(Long lastSequence) {
+        this.lastSequence = lastSequence;
     }
 }

--- a/src/backend/service-server/src/main/java/com/bbebig/serviceserver/channel/service/ChannelService.java
+++ b/src/backend/service-server/src/main/java/com/bbebig/serviceserver/channel/service/ChannelService.java
@@ -22,7 +22,6 @@ import com.bbebig.serviceserver.channel.repository.ChannelRepository;
 import com.bbebig.serviceserver.global.kafka.KafkaProducerService;
 import com.bbebig.serviceserver.server.entity.Server;
 import com.bbebig.serviceserver.server.entity.ServerMember;
-import com.bbebig.serviceserver.server.repository.MemberRedisRepositoryImpl;
 import com.bbebig.serviceserver.server.repository.ServerMemberRepository;
 import com.bbebig.serviceserver.server.repository.ServerRedisRepositoryImpl;
 import com.bbebig.serviceserver.server.repository.ServerRepository;
@@ -45,7 +44,6 @@ public class ChannelService {
     private final CategoryRepository categoryRepository;
 
     private final ServerRedisRepositoryImpl serverRedisRepository;
-    private final MemberRedisRepositoryImpl memberRedisRepository;
     private final ServerService serverService;
     private final KafkaProducerService kafkaProducerService;
 
@@ -76,6 +74,7 @@ public class ChannelService {
                 .position(position)
                 .channelType(channelCreateRequestDto.getChannelType())
                 .privateStatus(channelCreateRequestDto.isPrivateStatus())
+                .lastSequence(1L)
                 .build();
 
         channelRepository.save(channel);

--- a/src/backend/service-server/src/main/java/com/bbebig/serviceserver/global/client/SearchClient.java
+++ b/src/backend/service-server/src/main/java/com/bbebig/serviceserver/global/client/SearchClient.java
@@ -1,0 +1,13 @@
+package com.bbebig.serviceserver.global.client;
+
+import com.bbebig.commonmodule.clientDto.SearchFeignResponseDto.ServerChannelSequenceResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "search-server")
+public interface SearchClient {
+
+	@GetMapping("/feign/channels/{channelId}/sequence")
+	ServerChannelSequenceResponseDto getChannelLastSequence(@PathVariable(value = "channelId") Long channelId);
+}

--- a/src/backend/service-server/src/main/java/com/bbebig/serviceserver/server/dto/response/ServerReadResponseDto.java
+++ b/src/backend/service-server/src/main/java/com/bbebig/serviceserver/server/dto/response/ServerReadResponseDto.java
@@ -46,6 +46,7 @@ public class ServerReadResponseDto {
         private String channelType;
         private boolean privateStatus;
         private final List<Long> channelMemberIdList;
+        private Long lastSequence;
     }
 
     @Data
@@ -70,15 +71,8 @@ public class ServerReadResponseDto {
         }
     }
 
-    public static ServerReadResponseDto convertToServerReadResponseDto(Server server, List<Channel> channelList, List<Category> categoryList,
-                                                                        Map<Long, List<ChannelMember>> channelMemberMap) {
+    public static ServerReadResponseDto convertToServerReadResponseDto(Server server, List<Category> categoryList, List<ChannelInfo> channelInfoList) {
         List<CategoryInfo> categoryInfoList = new ArrayList<>();
-
-        List<ChannelInfo> channelInfoList = new ArrayList<>();
-        for (Channel channel : channelList) {
-            ChannelInfo channelInfo = convertToChannelInfo(channel, channelMemberMap.get(channel.getId()).stream().map(channelMember -> channelMember.getServerMember().getMemberId()).toList());
-            channelInfoList.add(channelInfo);
-        }
 
         for (Category category : categoryList) {
             CategoryInfo categoryInfo = convertToCategoryInfo(category);
@@ -95,7 +89,7 @@ public class ServerReadResponseDto {
                 .build();
     }
 
-    public static ChannelInfo convertToChannelInfo(Channel channel, List<Long> channelMemberIdList) {
+    public static ChannelInfo convertToChannelInfo(Channel channel, List<Long> channelMemberIdList, Long lastSequence) {
         return ChannelInfo.builder()
                 .channelId(channel.getId())
                 .categoryId(channel.getCategory() == null ? null : channel.getCategory().getId())
@@ -104,6 +98,7 @@ public class ServerReadResponseDto {
                 .channelType(channel.getChannelType().name())
                 .channelMemberIdList(channelMemberIdList)
                 .privateStatus(channel.isPrivateStatus())
+                .lastSequence(lastSequence)
                 .build();
     }
 

--- a/src/backend/service-server/src/main/java/com/bbebig/serviceserver/server/repository/ServerRedisRepositoryImpl.java
+++ b/src/backend/service-server/src/main/java/com/bbebig/serviceserver/server/repository/ServerRedisRepositoryImpl.java
@@ -154,4 +154,13 @@ public class ServerRedisRepositoryImpl implements ServerRedisRepository {
 		String key = ServerRedisKeys.getServerChannelListKey(serverId);
 		redisSetTemplate.delete(key);
 	}
+
+	/**
+	 * 서버별 채널 시퀀스 정보를 가져 옴
+	 * (serverChannel:{serverId}:channelSequence) => ChannelId, Sequence
+	 */
+	public Long getServerChannelSequence(Long channelId) {
+		String redisKey = ServerRedisKeys.getServerChannelSequenceKey(channelId);
+		return redisSetTemplate.opsForValue().get(redisKey);
+	}
 }

--- a/src/backend/service-server/src/main/java/com/bbebig/serviceserver/server/service/ServerService.java
+++ b/src/backend/service-server/src/main/java/com/bbebig/serviceserver/server/service/ServerService.java
@@ -1,5 +1,7 @@
 package com.bbebig.serviceserver.server.service;
 
+import com.bbebig.commonmodule.clientDto.SearchFeignResponseDto;
+import com.bbebig.commonmodule.clientDto.SearchFeignResponseDto.ServerChannelSequenceResponseDto;
 import com.bbebig.commonmodule.clientDto.ServiceFeignResponseDto.*;
 import com.bbebig.commonmodule.clientDto.StateFeignResponseDto.ServerMemberPresenceResponseDto;
 import com.bbebig.commonmodule.clientDto.UserFeignResponseDto.*;
@@ -21,6 +23,7 @@ import com.bbebig.serviceserver.channel.entity.ChannelType;
 import com.bbebig.serviceserver.channel.repository.ChannelMemberRepository;
 import com.bbebig.serviceserver.channel.repository.ChannelRepository;
 import com.bbebig.serviceserver.global.client.MemberClient;
+import com.bbebig.serviceserver.global.client.SearchClient;
 import com.bbebig.serviceserver.global.client.StateClient;
 import com.bbebig.serviceserver.global.kafka.KafkaProducerService;
 import com.bbebig.serviceserver.server.dto.request.ServerCreateRequestDto;
@@ -62,6 +65,7 @@ public class ServerService {
 
     private final MemberClient memberClient;
     private final StateClient stateClient;
+    private final SearchClient searchClient;
     private final ServerRedisRepositoryImpl serverRedisRepositoryImpl;
 
 
@@ -171,8 +175,8 @@ public class ServerService {
             List<ChannelMember> channelMemberList = channelMemberRepository.findAllByChannelId(channel.getId());
             Long sequence = serverRedisRepositoryImpl.getServerChannelSequence(channel.getId());
             if (sequence == null) {
-                // TODO : 예외처리 구현
-                sequence = 0L;
+                ServerChannelSequenceResponseDto channelLastSequence = searchClient.getChannelLastSequence(channel.getId());
+                sequence = channelLastSequence.getLastSequence();
             }
             channel.updateLastSequence(sequence);
             channelRepository.save(channel);

--- a/src/backend/service-server/src/main/java/com/bbebig/serviceserver/server/service/ServerService.java
+++ b/src/backend/service-server/src/main/java/com/bbebig/serviceserver/server/service/ServerService.java
@@ -178,6 +178,7 @@ public class ServerService {
                 ServerChannelSequenceResponseDto channelLastSequence = searchClient.getChannelLastSequence(channel.getId());
                 sequence = channelLastSequence.getLastSequence();
             }
+            // TODO : 추후에 채널별 마지막으로 발행된 시퀀스 번호를 주기적으로 DB에 저장하는 로직 구현
             channel.updateLastSequence(sequence);
             channelRepository.save(channel);
 


### PR DESCRIPTION
## 📎 연관 이슈

해결된 이슈: close #324 

## ✏️ 작업 내용
- 채널별 시퀀스를 PostgreSql에 저장하는 기능 구현
- 시퀀스 정보가 없을 시 몽고 DB에서 마지막 시퀀스를 조회하여 캐싱하는 기능 구현
