### PR TITLE
[BE] 리프레시 토큰을 바디로 보냅니다. #389

### DIFF
--- a/src/backend/auth-server/src/routes/auth/index.ts
+++ b/src/backend/auth-server/src/routes/auth/index.ts
@@ -3,7 +3,6 @@ import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import {
   healthCheckSchema,
   logoutSchema,
-  mobileSignInSchema,
   refreshTokenMobileSchema,
   refreshTokenSchema,
   registerSchema,
@@ -27,13 +26,6 @@ const authRoute = async (app: FastifyInstance) => {
     url: '/login',
     schema: signInSchema,
     handler: authController.login,
-  });
-
-  app.withTypeProvider<ZodTypeProvider>().route({
-    method: 'POST',
-    url: '/mobile-login',
-    schema: mobileSignInSchema,
-    handler: authController.mobileLogin,
   });
 
   app.withTypeProvider<ZodTypeProvider>().route({

--- a/src/backend/auth-server/src/schema/authSchema.ts
+++ b/src/backend/auth-server/src/schema/authSchema.ts
@@ -14,25 +14,6 @@ const signInSchema = {
       message: z.string().default('Login Ok!'),
       result: z.object({
         accessToken: z.string(),
-      }),
-    }),
-    400: commonResponseSchemaOmitResult,
-  },
-};
-
-const mobileSignInSchema = {
-  tags: ['auth'],
-  description: '모바일 로그인 합니다.',
-  body: z.object({
-    email: z.string().email(),
-    password: z.string(),
-  }),
-  response: {
-    200: z.object({
-      code: z.string().default('AUTH100'),
-      message: z.string().default('Login Ok!'),
-      result: z.object({
-        accessToken: z.string(),
         refreshToken: z.string(),
       }),
     }),
@@ -88,6 +69,7 @@ const refreshTokenSchema = {
       message: z.string().default('refresh success'),
       result: z.object({
         accessToken: z.string(),
+        refreshToken: z.string(),
       }),
     }),
     400: commonResponseSchemaOmitResult,
@@ -211,7 +193,6 @@ export {
   verifyTokenSchema,
   registerSchema,
   signInSchema,
-  mobileSignInSchema,
   verifyEmailSchema,
   tokenDecodeSchema,
   healthCheckSchema,


### PR DESCRIPTION
## 📎 연관 이슈

해결된 이슈: close #389

## ✏️ 작업 내용

서버와 클라이언트간의 도메인이 다르기 때문에 클라이언트에서 쿠키가 삭제되어 해당 쿠키를 클라이언트에서 설정하여 사용하도록 수정하였습니다.

공통된 값을 응답하는 mobile 관련 엔드포인트는 삭제되었으며, 동일한 url로 요청하면 됩니다.

`/login` 엔드포인트로 요청할 경우. body로 access, refresh 둘 다 응답합니다.

## 🙏🏻 리뷰 요구 사항

## 📷 스크린샷 (선택 사항)
