### PR TITLE
[FE] 리프레시토큰을 클라이언트에서 관리합니다. #389

### DIFF
--- a/src/frontend/src/apis/config/interceptor.ts
+++ b/src/frontend/src/apis/config/interceptor.ts
@@ -35,7 +35,7 @@ export async function handleApiError(error: AxiosError) {
 export async function handleTokenError(error: AxiosError) {
   if (error.response?.status === 401) {
     cookie.deleteCookie(COOKIE_KEYS.ACCESS_TOKEN)
-    window.location.href = '/login'
+    cookie.deleteCookie(COOKIE_KEYS.REFRESH_TOKEN)
   }
   return Promise.reject(error)
 }

--- a/src/frontend/src/apis/schema/auth.ts
+++ b/src/frontend/src/apis/schema/auth.ts
@@ -12,7 +12,8 @@ const loginRequestSchema = z.object({
 
 const loginResponseSchema = commonResponseSchema.extend({
   result: z.object({
-    accessToken: z.string()
+    accessToken: z.string(),
+    refreshToken: z.string()
   })
 })
 

--- a/src/frontend/src/apis/service/auth.ts
+++ b/src/frontend/src/apis/service/auth.ts
@@ -16,19 +16,19 @@ export interface CustomAxiosRequestConfig extends AxiosRequestConfig {
   useAuth?: boolean
 }
 
-const LOGIN_STATUS_DISABLED_CODE = 'AUTH110'
-
 const authService = () => {
   const statusCheck = async () => {
     const res = await axiosInstance.get<StatusCheckResponseSchema>(`${BASE_PATH}/status-check`, {
       headers: {
-        Authorization: `Bearer ${cookie.getCookie(COOKIE_KEYS.ACCESS_TOKEN)}`
+        Authorization: `Bearer ${cookie.getCookie(COOKIE_KEYS.ACCESS_TOKEN)}`,
+        'refresh-token': `${cookie.getCookie(COOKIE_KEYS.REFRESH_TOKEN)}`
       },
       useAuth: false
     } as CustomAxiosRequestConfig)
 
-    if (res.data.code === LOGIN_STATUS_DISABLED_CODE) {
+    if (!res.data.result.status) {
       cookie.deleteCookie(COOKIE_KEYS.ACCESS_TOKEN)
+      cookie.deleteCookie(COOKIE_KEYS.REFRESH_TOKEN)
     }
 
     return res.data
@@ -39,7 +39,9 @@ const authService = () => {
       useAuth: false
     } as CustomAxiosRequestConfig)
     const accessToken = res.data.result.accessToken
+    const refreshToken = res.data.result.refreshToken
     cookie.setCookie(COOKIE_KEYS.ACCESS_TOKEN, accessToken)
+    cookie.setCookie(COOKIE_KEYS.REFRESH_TOKEN, refreshToken)
   }
 
   const register = async (data: RegisterSchema) => {
@@ -51,16 +53,28 @@ const authService = () => {
 
   const logout = async () => {
     try {
-      await axiosInstance.post(`${BASE_PATH}/logout`)
+      await axiosInstance.post(`${BASE_PATH}/logout`, {}, {
+        headers: {
+          Authorization: `Bearer ${cookie.getCookie(COOKIE_KEYS.ACCESS_TOKEN)}`,
+          'refresh-token': `${cookie.getCookie(COOKIE_KEYS.REFRESH_TOKEN)}`
+        },
+        useAuth: false
+      } as CustomAxiosRequestConfig)
     } catch (error) {
       console.error(error)
     } finally {
       cookie.deleteCookie(COOKIE_KEYS.ACCESS_TOKEN)
+      cookie.deleteCookie(COOKIE_KEYS.REFRESH_TOKEN)
     }
   }
 
   const refreshToken = async () => {
-    const response = await axiosInstance.post(`${BASE_PATH}/refresh`)
+    const response = await axiosInstance.post(`${BASE_PATH}/refresh`, {}, {
+      headers: {
+        'refresh-token': `${cookie.getCookie(COOKIE_KEYS.REFRESH_TOKEN)}`
+      },
+      useAuth: false
+    } as CustomAxiosRequestConfig)
     return response.data
   }
 

--- a/src/frontend/src/constants/keys.ts
+++ b/src/frontend/src/constants/keys.ts
@@ -1,5 +1,6 @@
 const COOKIE_KEYS = {
-  ACCESS_TOKEN: 'access_token'
+  ACCESS_TOKEN: 'access_token',
+  REFRESH_TOKEN: 'refresh_token'
 } as const
 
 const LOCAL_STORAGE = {

--- a/src/frontend/src/hooks/queries/auth/useLogoutMutation.ts
+++ b/src/frontend/src/hooks/queries/auth/useLogoutMutation.ts
@@ -1,16 +1,14 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 
 import authService from '@/apis/service/auth'
 import { UseMutationCustomOptions } from '@/types/common'
 
 export function useLogoutMutation(config?: UseMutationCustomOptions<void>) {
-  const queryClient = useQueryClient()
-
   return useMutation({
     ...config,
     mutationFn: authService.logout,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['statusCheck'] })
+      window.location.href = '/'
     }
   })
 }

--- a/src/frontend/src/hooks/queries/auth/useStatusCheckMutation.ts
+++ b/src/frontend/src/hooks/queries/auth/useStatusCheckMutation.ts
@@ -9,7 +9,6 @@ export function useStatusCheckMutation(
 ) {
   return useMutation({
     ...config,
-    mutationFn: authService.statusCheck,
-    mutationKey: ['statusCheck']
+    mutationFn: authService.statusCheck
   })
 }

--- a/src/frontend/src/layouts/main-layout/components/profile-card/index.tsx
+++ b/src/frontend/src/layouts/main-layout/components/profile-card/index.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useRef, useState } from 'react'
 import { toast } from 'react-hot-toast'
-import { useNavigate } from 'react-router-dom'
 
 import { CommonResponseType } from '@/apis/schema/types/common'
 import { GetUserSelfResponseSchema } from '@/apis/schema/types/user'
@@ -92,7 +91,6 @@ export function Content({
     }
   })
 
-  const navigate = useNavigate()
   const { mutate: logout } = useLogoutMutation()
 
   const statusMenuRef = useRef<HTMLDivElement>(null)
@@ -111,7 +109,6 @@ export function Content({
 
   const handleClickLogout = () => {
     logout(undefined)
-    navigate('/', { replace: true })
   }
 
   const menuItems = [

--- a/src/frontend/src/pages/landing/components/header.tsx
+++ b/src/frontend/src/pages/landing/components/header.tsx
@@ -41,6 +41,7 @@ function Header() {
   const [isLogin, setIsLogin] = useState(false)
   const { mutate: statusCheck } = useStatusCheckMutation({
     onSuccess: (data) => {
+      console.log(data.result.status)
       setIsLogin(data.result.status)
     }
   })

--- a/src/frontend/src/utils/cookie.ts
+++ b/src/frontend/src/utils/cookie.ts
@@ -9,7 +9,7 @@ function cookie() {
 
   const setCookie = (name: string, value: string) => {
     const expires = new Date(Date.now() + COOKIE_EXPIRE_TIME * 24 * 60 * 60 * 1000).toUTCString()
-    document.cookie = `${name}=${value}; path=/; expires=${expires}; samesite=strict`
+    document.cookie = `${name}=${value}; path=/; expires=${expires};`
   }
 
   const deleteCookie = (name: string) => {


### PR DESCRIPTION
## 📎 연관 이슈

해결된 이슈: close #389

## ✏️ 작업 내용

서버와 클라이언트의 도메인이 달라 SameSite 정책으로 인해 쿠키가 정상적으로 전달되지 않았습니다.  
이에 따라 쿠키 대신 body를 통해 토큰을 전달받아 인증하도록 변경했습니다.  

또한, 쿠키 탈취 가능성을 고려하여 리프레시 토큰의 유효기간을 단축하고,  
레디스에서도 TTL을 설정하여 일정 시간이 지나면 자동 삭제되도록 처리했습니다.
