### PR TITLE
[BE] 검색서버 카프카 리팩토링 및 학습 #402

### DIFF
--- a/script/docker/docker-compose-kafka.yml
+++ b/script/docker/docker-compose-kafka.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - '9092:9092'  # 호스트:컨테이너
     environment:
-      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
       # KRaft 설정
       - KAFKA_CFG_BROKER_ID=0
       - KAFKA_CFG_NODE_ID=0
@@ -35,7 +35,7 @@ services:
     ports:
       - '9093:9092'  # 호스트:컨테이너
     environment:
-      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
       # KRaft 설정
       - KAFKA_CFG_BROKER_ID=1
       - KAFKA_CFG_NODE_ID=1
@@ -62,7 +62,7 @@ services:
     ports:
       - '9094:9092'  # 호스트:컨테이너
     environment:
-      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
       # KRaft 설정
       - KAFKA_CFG_BROKER_ID=2
       - KAFKA_CFG_NODE_ID=2

--- a/src/backend/common-module/src/main/java/com/bbebig/commonmodule/kafka/config/KafkaChannelChatEventConsumerConfig.java
+++ b/src/backend/common-module/src/main/java/com/bbebig/commonmodule/kafka/config/KafkaChannelChatEventConsumerConfig.java
@@ -4,6 +4,7 @@ import com.bbebig.commonmodule.kafka.dto.ChatMessageDto;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,18 +12,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
-import org.springframework.kafka.core.ConsumerFactory;
-import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.*;
 import org.springframework.kafka.listener.ConsumerAwareRebalanceListener;
 import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.FixedBackOff;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-@EnableKafka
 @Configuration
+@EnableKafka
 @Slf4j
 public class KafkaChannelChatEventConsumerConfig {
 
@@ -32,8 +35,43 @@ public class KafkaChannelChatEventConsumerConfig {
 	@Value("${spring.kafka.consumer.group-id.channel-chat-event}")
 	private String baseGroupId;
 
-	@Value(("${eureka.instance.instance-id}"))
+	@Value("${eureka.instance.instance-id}")
 	private String instanceId;
+
+	// Producer side (for DLT)
+	@Bean
+	public Map<String, Object> producerConfigs() {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, org.apache.kafka.common.serialization.StringSerializer.class);
+		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, org.springframework.kafka.support.serializer.JsonSerializer.class);
+		props.put(ProducerConfig.ACKS_CONFIG, "all");
+		return props;
+	}
+
+	@Bean
+	public ProducerFactory<String, Object> producerFactorForChannelDLQ() {
+		return new DefaultKafkaProducerFactory<>(producerConfigs());
+	}
+
+	@Bean
+	public KafkaTemplate<String, Object> kafkaTemplateForChannelDLQ() {
+		return new KafkaTemplate<>(producerFactorForChannelDLQ());
+	}
+
+	@Bean
+	public DeadLetterPublishingRecoverer deadLetterPublishingRecoverer(KafkaTemplate<String, Object> kafkaTemplate) {
+		return new DeadLetterPublishingRecoverer(kafkaTemplate);
+	}
+
+	@Bean
+	public DefaultErrorHandler defaultErrorHandler(DeadLetterPublishingRecoverer recoverer) {
+		FixedBackOff backOff = new FixedBackOff(1000L, 3L);
+		DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
+		return errorHandler;
+	}
+
+	//Consumer side
 
 	private Map<String, Object> consumerConfigurations() {
 		String groupId = baseGroupId + "-" + instanceId;
@@ -41,28 +79,33 @@ public class KafkaChannelChatEventConsumerConfig {
 		configurations.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
 		configurations.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
 		configurations.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		configurations.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,JsonDeserializer.class);
-		configurations.put(JsonDeserializer.TRUSTED_PACKAGES,"*");
-		configurations.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,"latest"); // earliest: 전체 , latest: 최신 메시지
+		configurations.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configurations.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+
 		return configurations;
 	}
 
-	// 채팅 관련 Consumer 생성
 	@Bean
 	public ConsumerFactory<String, ChatMessageDto> consumerFactoryForChannelChatEvent(){
-		return new DefaultKafkaConsumerFactory<>(consumerConfigurations(), new StringDeserializer(),
-				new JsonDeserializer<>(ChatMessageDto.class));
+		return new DefaultKafkaConsumerFactory<>(
+				consumerConfigurations(),
+				new StringDeserializer(),
+				new JsonDeserializer<>(ChatMessageDto.class)
+		);
 	}
 
-	// 멀티쓰레드에 대한 동기화 제공하는 컨슈머를 생산하기 위한 Factory
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, ChatMessageDto> channelChatListener(){
+	public ConcurrentKafkaListenerContainerFactory<String, ChatMessageDto> channelChatListener(
+			DefaultErrorHandler errorHandler
+	){
 		ConcurrentKafkaListenerContainerFactory<String, ChatMessageDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
 		factory.setConsumerFactory(consumerFactoryForChannelChatEvent());
-		ContainerProperties prop = factory.getContainerProperties();
-		prop.setConsumerRebalanceListener(rebalanceListener());
-		factory.setConcurrency(3); // 쓰레드 개수
+		factory.setConcurrency(3);
 		factory.setBatchListener(true);
+		factory.setCommonErrorHandler(errorHandler);
+
+		ContainerProperties props = factory.getContainerProperties();
+		props.setConsumerRebalanceListener(rebalanceListener());
 		return factory;
 	}
 
@@ -72,11 +115,10 @@ public class KafkaChannelChatEventConsumerConfig {
 			@Override
 			public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
 				partitions.forEach(partition ->
-					log.info("[Chat] 할당된 파티션: Topic: {}, Partition: {}", partition.topic(), partition.partition())
+						log.info("[Chat] 할당된 파티션: Topic: {}, Partition: {}", partition.topic(), partition.partition())
 				);
 			}
 		};
 	}
-
 
 }

--- a/src/backend/common-module/src/main/java/com/bbebig/commonmodule/kafka/config/KafkaChannelChatEventConsumerConfig.java
+++ b/src/backend/common-module/src/main/java/com/bbebig/commonmodule/kafka/config/KafkaChannelChatEventConsumerConfig.java
@@ -62,6 +62,7 @@ public class KafkaChannelChatEventConsumerConfig {
 		ContainerProperties prop = factory.getContainerProperties();
 		prop.setConsumerRebalanceListener(rebalanceListener());
 		factory.setConcurrency(3); // 쓰레드 개수
+		factory.setBatchListener(true);
 		return factory;
 	}
 

--- a/src/backend/search-server/build.gradle
+++ b/src/backend/search-server/build.gradle
@@ -79,6 +79,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // Resilience4j
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.0.2'
 }
 
 dependencyManagement {

--- a/src/backend/search-server/build.gradle
+++ b/src/backend/search-server/build.gradle
@@ -81,7 +81,8 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // Resilience4j
-    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.0.2'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+
 }
 
 dependencyManagement {

--- a/src/backend/search-server/src/main/java/com/bbebig/searchserver/domain/search/service/ChannelEventConsumerService.java
+++ b/src/backend/search-server/src/main/java/com/bbebig/searchserver/domain/search/service/ChannelEventConsumerService.java
@@ -1,4 +1,0 @@
-package com.bbebig.searchserver.domain.search.service;
-
-public class ChannelEventConsumerService {
-}

--- a/src/backend/search-server/src/main/java/com/bbebig/searchserver/domain/search/service/ChannelMessageBatchService.java
+++ b/src/backend/search-server/src/main/java/com/bbebig/searchserver/domain/search/service/ChannelMessageBatchService.java
@@ -1,0 +1,100 @@
+package com.bbebig.searchserver.domain.search.service;
+
+import com.bbebig.commonmodule.kafka.dto.ChatMessageDto;
+import com.bbebig.searchserver.domain.history.service.HistoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChannelMessageBatchService {
+
+	private final HistoryService historyService;
+
+	public void processChannelMessages(List<ChatMessageDto> messageBatch) {
+		// 1) 메세지를 메시지 타입/동작에 따라 grouping
+		List<ChatMessageDto> toCreate = new ArrayList<>();
+		List<ChatMessageDto> toUpdate = new ArrayList<>();
+		List<Long> toDeleteIds = new ArrayList<>();
+
+		for (ChatMessageDto dto : messageBatch) {
+			switch (dto.getType()) {
+				case MESSAGE_CREATE:
+					toCreate.add(dto);
+					break;
+				case MESSAGE_UPDATE:
+					toUpdate.add(dto);
+					break;
+				case MESSAGE_DELETE:
+					toDeleteIds.add(dto.getId());
+					break;
+				default:
+					log.error("Unknown message type: {}", dto);
+			}
+		}
+
+		// 2) bulk create
+		for (ChatMessageDto dto : toCreate) {
+			historyService.saveChannelMessage(dto);
+		}
+
+		// 3) bulk update
+		for (ChatMessageDto dto : toUpdate) {
+			historyService.updateChannelMessage(dto);
+		}
+
+		// 4) bulk delete
+		for (Long id : toDeleteIds) {
+			historyService.deleteChannelMessage(id);
+		}
+
+		log.info("[Search] ChannelMessageBatchService: batch process 성공. create={}, update={}, delete={}",
+				toCreate.size(), toUpdate.size(), toDeleteIds.size());
+	}
+
+	public void processDmMessages(List<ChatMessageDto> messageBatch) {
+		// 1) 메세지를 메시지 타입/동작에 따라 grouping
+		List<ChatMessageDto> toCreate = new ArrayList<>();
+		List<ChatMessageDto> toUpdate = new ArrayList<>();
+		List<Long> toDeleteIds = new ArrayList<>();
+
+		for (ChatMessageDto dto : messageBatch) {
+			switch (dto.getType()) {
+				case MESSAGE_CREATE:
+					toCreate.add(dto);
+					break;
+				case MESSAGE_UPDATE:
+					toUpdate.add(dto);
+					break;
+				case MESSAGE_DELETE:
+					toDeleteIds.add(dto.getId());
+					break;
+				default:
+					log.error("Unknown message type: {}", dto);
+			}
+		}
+
+		// 2) bulk create
+		for (ChatMessageDto dto : toCreate) {
+			historyService.saveDmMessage(dto);
+		}
+
+		// 3) bulk update
+		for (ChatMessageDto dto : toUpdate) {
+			historyService.updateDmMessage(dto);
+		}
+
+		// 4) bulk delete
+		for (Long id : toDeleteIds) {
+			historyService.deleteDmMessage(id);
+		}
+
+		log.info("[Search] DmMessageBatchService: batch process 성공. create={}, update={}, delete={}",
+				toCreate.size(), toUpdate.size(), toDeleteIds.size());
+	}
+}

--- a/src/backend/search-server/src/main/java/com/bbebig/searchserver/domain/search/service/MessageEventConsumerService.java
+++ b/src/backend/search-server/src/main/java/com/bbebig/searchserver/domain/search/service/MessageEventConsumerService.java
@@ -1,54 +1,44 @@
 package com.bbebig.searchserver.domain.search.service;
 
-import com.bbebig.commonmodule.global.response.code.error.ErrorStatus;
-import com.bbebig.commonmodule.global.response.exception.ErrorHandler;
 import com.bbebig.commonmodule.kafka.dto.ChatMessageDto;
-import com.bbebig.commonmodule.kafka.dto.model.ChannelType;
 import com.bbebig.commonmodule.kafka.dto.model.ChatType;
 import com.bbebig.searchserver.domain.history.service.HistoryService;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MessageEventConsumerService {
 
+	private final ChannelMessageBatchService batchService;
 	private final HistoryService historyService;
 
+	private final CircuitBreakerRegistry registry;
+
 	/**
-	 * 채널 채팅 메시지 이벤트 처리 (CREATE, UPDATE, DELETE)
+	 * 채널 채팅 메시지 이벤트 Batch 처리 (CREATE, UPDATE, DELETE)
 	 */
 	@KafkaListener(topics = "${spring.kafka.topic.channel-chat-event}", groupId = "${spring.kafka.consumer.group-id.channel-chat-event}", containerFactory = "channelChatListener")
-	public void consumeForChannelChatEvent(ChatMessageDto chatMessageDto) {
-		if (chatMessageDto == null) {
+	public void consumeForChannelChatEvent(List<ChatMessageDto> messageDtos) {
+		if (messageDtos == null || messageDtos.isEmpty()) {
 			log.error("[Search] MessageEventConsumerService: 채팅 메시지 정보 없음");
-			throw new ErrorHandler(ErrorStatus.KAFKA_CONSUME_NULL_EVENT);
+			return;
 		}
-
-		if (chatMessageDto.getChatType() != ChatType.CHANNEL) {
-			log.error("[Chat] MessageEventConsumerService: 채널 채팅 메시지가 아닙니다. ChatMessageDto: {}", chatMessageDto);
-			throw new ErrorHandler(ErrorStatus.CHAT_TYPE_INVALID);
-		}
-
-		// 개발용 로그
-		log.info("[Chat] MessageEventConsumerService에서 메시지 이벤트 수신: ChatMessageDto: {}", chatMessageDto);
-
-		switch (chatMessageDto.getType()) {
-			case MESSAGE_CREATE:
-				historyService.saveChannelMessage(chatMessageDto);
-				break;
-			case MESSAGE_UPDATE:
-				historyService.updateChannelMessage(chatMessageDto);
-				break;
-			case MESSAGE_DELETE:
-				historyService.deleteChannelMessage(chatMessageDto.getId());
-				break;
-			default:
-				log.warn("[Chat] MessageEventConsumerService: 처리할 수 없는 메시지 타입. ChatMessageDto: {}", chatMessageDto);
-				throw new ErrorHandler(ErrorStatus.INVALID_MESSAGE_EVENT_TYPE);
+		CircuitBreaker cb = registry.circuitBreaker("channelChatConsumer");
+		try {
+			CircuitBreaker.decorateRunnable(cb, () -> {
+				batchService.processChannelMessages(messageDtos);
+			}).run();
+		} catch (Throwable throwable) {
+			log.error("[Chat] Batch consume fail, fallback or store to DLT. reason={}", throwable.getMessage());
+			// TODO: fallback: e.g. send to DeadLetterTopic
 		}
 	}
 
@@ -59,12 +49,12 @@ public class MessageEventConsumerService {
 	public void consumeForDmChatEvent(ChatMessageDto chatMessageDto) {
 		if (chatMessageDto == null) {
 			log.error("[Search] MessageEventConsumerService: 채팅 메시지 정보 없음");
-			throw new ErrorHandler(ErrorStatus.KAFKA_CONSUME_NULL_EVENT);
+			return;
 		}
 
 		if (chatMessageDto.getChatType() != ChatType.DM) {
 			log.error("[Chat] MessageEventConsumerService: DM 채팅 메시지가 아닙니다. ChatMessageDto: {}", chatMessageDto);
-			throw new ErrorHandler(ErrorStatus.CHAT_TYPE_INVALID);
+			return;
 		}
 
 		switch (chatMessageDto.getType()) {
@@ -79,7 +69,6 @@ public class MessageEventConsumerService {
 				break;
 			default:
 				log.warn("[Chat] MessageEventConsumerService: 처리할 수 없는 메시지 타입. ChatMessageDto: {}", chatMessageDto);
-				throw new ErrorHandler(ErrorStatus.INVALID_MESSAGE_EVENT_TYPE);
 		}
 	}
 }

--- a/src/backend/search-server/src/main/resources/application.yml
+++ b/src/backend/search-server/src/main/resources/application.yml
@@ -74,6 +74,34 @@ auth:
   server:
     url: ${AUTH_SERVER_URL}
 
+
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 5000
+        readTimeout: 5000
+
+  circuitbreaker:
+    enabled: true
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        waitDurationInOpenState: 30s # HALF_OPEN 상태로 빨리 전환되어 장애가 복구 될 수 있도록 기본값(60s)보다 작게 설정
+        slowCallRateThreshold: 80 # slowCall 발생 시 서버 스레드 점유로 인해 장애가 생길 수 있으므로 기본값(100)보다 조금 작게 설정
+        slowCallDurationThreshold: 5s # 위와 같은 이유로 5초를 slowCall로 판단함. 해당 값은 TimeLimiter의 timeoutDuration보다 작아야 함
+        registerHealthIndicator: true
+    instances:
+      default:
+        baseConfig: default
+  timelimiter:
+    configs:
+      default:
+        timeoutDuration: 6s # slowCallDurationThreshold보다는 크게 설정되어야 함
+        cancelRunningFuture: true
+
 logging:
   level:
     org.apache.kafka: WARN

--- a/src/backend/search-server/src/main/resources/application.yml
+++ b/src/backend/search-server/src/main/resources/application.yml
@@ -32,6 +32,7 @@ spring:
       bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
 
     consumer:
+      max-poll-records: 100
       group-id:
         channel-chat-event: "${spring.application.name}-channelChatEventGroup"
         dm-chat-event: "${spring.application.name}-dmChatEventGroup"
@@ -43,7 +44,7 @@ spring:
         member-event: "${spring.application.name}-memberEventGroup"
 
       enable-auto-commit: true
-      auto-offset-reset: latest
+      auto-offset-reset: earliest
 
 server:
   port: 9030


### PR DESCRIPTION
## 📎 연관 이슈

해결된 이슈: close #402

## ✏️ 작업 내용

### 카프카 유실 방지, 중복 방지
Message Delivery Semantics에 따르면, Exactly Once와 At least Once로 되어 있다. (Default 값은 At least once)

검색 서버에서는 메시지가 유실 되어서는 안되지만, 만약 중복처리 된다하더라도  DB에 중복 값이 들어가지 않는 등 크리티컬 하지 않기 때문에, 상대적으로 어려운 Exactly Once로 설정을 커스터 마이징 하는 것 보단 At least Once로 유실만 방지하기로 하여 따로 설정을 바꾸지 않았습니다.

또한 유실과 관련하여서, 카프카 acks Option은 3.0이상 버전에서는 기본값이 All 이 되어 유실을 방지할 수 있어 따로 설정을 건들지 않았습니다.(이외에도 enable.idempotence=true 등 3.0 이상에서는 멱등성 옵션이 기본 활성화)

다만 서버 재 기동간에 브로커에 메시지가 적재되면 현재 설정으로는 그 전 메시지를 처리 하지 않아 유실되기 때문에, auto.offset.reset=earliest (기본은 Latest)로 변경하여 유실을 방지하였습니다.


#### 메시지 처리 오류 시 
kafka의 defaultErrorHandler와 FixedBackOff를 활용해 1초 간격으로 최대 3번 재시도 후 , recoverer로 DeadLetterPublishingRecoverer을 활용해 카프카가 {원본 토픽 명}-DLT로 토픽을 만들어주고, 전송합니다.

이후 이 DLT를 처리하는 로직을 만들어 모니터링을 하던지 재시도 처리하려고 합니다.

### Batch 처리
카프카에서는 Batch처리를 기본적으로 지원해줍니다. 따라서,  max.poll.records = 100 으로 설정하여 poll() 시점에 최대 100개까지 한번에 가져와 처리할 수 있도록 설정하였습니다.